### PR TITLE
Add python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python: 2.7
 env:
   - TOX_ENV=pep8
   - TOX_ENV=py27
+  - TOX_ENV=py34
 install:
   - pip install tox
 script:

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ It is available on pypi so you can install it as follows:
 
 The parsed config can be seen as a nested dictionary (with types automatically inferred) where values can be accessed using normal
 dictionary getter (e.g., `conf['a']['b']` or using paths like `conf['a.b']`) or via the methods `get`, `get_int` (throws an exception
-if it is not an int), `get_string`, `get_list`, `get_double`, `get_bool`, `get_config`.
+if it is not an int), `get_string`, `get_list`, `get_float`, `get_bool`, `get_config`.
 
     from pyhocon import ConfigFactory
-    
+
     conf = ConfigFactory.parse_file('samples/database.conf')
     host = conf.get_string('databases.mysql.host')
     same_host = conf.get('databases.mysql.host')
@@ -56,7 +56,7 @@ if it is not an int), `get_string`, `get_list`, `get_double`, `get_bool`, `get_c
           retries = 3
         }
       }
-    
+
       // multi line support
       motd = """
                 Hello "man"!
@@ -68,19 +68,19 @@ if it is not an int), `get_string`, `get_list`, `get_double`, `get_bool`, `get_c
         "192.168.0.2" // optional quotes
         192.168.0.3, # can have a trailing , which is ok
       ]
-    
+
       # you can use substitution with unquoted strings
       retries_msg = You have ${databases.mysql.retries} retries
     }
-    
+
 ## Conversion tool
 
 We provide a conversion tool to convert from HOCON to the JSON, .properties and YAML formats.
 
     usage: pyhocon [-h] [-i INPUT] [-o OUTPUT] [-f FORMAT]
-    
+
     pyhocon tool
-    
+
     optional arguments:
       -h, --help            show this help message and exit
       -i INPUT, --input INPUT FILE
@@ -93,7 +93,7 @@ If -i is omitted, the tool will read from the standard input. If -o is omitted, 
 ####  JSON
 
     $ cat samples/database.conf | pyhocon -f json
-    
+
     {
       "databases": {
         "active": true,
@@ -116,7 +116,7 @@ If -i is omitted, the tool will read from the standard input. If -o is omitted, 
       "motd": "\n            Hello \"man\"!\n            How is it going?\n         ",
       "retries_msg": "You have 3 retries"
     }
-    
+
 ####  .properties
 
     $ cat samples/database.conf | pyhocon -f properties
@@ -135,9 +135,9 @@ If -i is omitted, the tool will read from the standard input. If -o is omitted, 
     motd = \
                 Hello "man"\!\
                 How is it going?\
-    
+
     retries_msg = You have 3 retries
-        
+
 #### YAML
 
     $ cat samples/database.conf | pyhocon -f yaml
@@ -158,10 +158,10 @@ If -i is omitted, the tool will read from the standard input. If -o is omitted, 
         - 192.168.0.2
         - 192.168.0.3
     motd: |
-    
+
                 Hello "man"!
                 How is it going?
-    
+
     retries_msg: You have 3 retries
 
 ## Includes
@@ -188,7 +188,7 @@ cat.conf:
       garfield: {
         say: meow
       }
-    }    
+    }
 
 dog.conf:
 
@@ -204,18 +204,18 @@ dog.conf:
         }
       }
     }
-    
+
 animals.conf:
-    
+
     {
       cat : {
         include "cat.conf"
       }
-    
+
       dog: {
         include "dog.conf"
       }
-    }    
+    }
 
 Then evaluating animals.conf will result in the followings:
 

--- a/pyhocon/__init__.py
+++ b/pyhocon/__init__.py
@@ -1,10 +1,17 @@
 import re
 import os
 import socket
-import urllib2
 from pyhocon.config_tree import ConfigTree, ConfigSubstitution, ConfigList, ConfigValues, ConfigUnquotedString
 from pyhocon.exceptions import ConfigSubstitutionException
 from pyparsing import *
+
+
+try:
+    # For Python 3.0 and later
+    from urllib.request import urlopen
+except ImportError:
+    # Fall back to Python 2's urllib2
+    from urllib2 import urlopen
 
 
 class ConfigFactory(object):
@@ -284,7 +291,7 @@ class ConfigTreeParser(TokenConverter):
         config_tree = ConfigTree()
         for element in token_list:
             # from include then merge items
-            expanded_tokens = element._dictionary.iteritems() if isinstance(element, ConfigTree) else [element]
+            expanded_tokens = element._dictionary.items() if isinstance(element, ConfigTree) else [element]
 
             for tokens in expanded_tokens:
                 # key, value1, value2, ...

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -20,7 +20,7 @@ class ConfigTree(object):
         """
         for key, value in b._dictionary.items():
             # if key is in both a and b and both values are dictionary then merge it otherwise override it
-            if key in a._dictionary.items() and isinstance(a._dictionary[key], ConfigTree) and isinstance(a._dictionary[key], ConfigTree):
+            if key in list(a._dictionary.items()) and isinstance(a._dictionary[key], ConfigTree) and isinstance(a._dictionary[key], ConfigTree):
                 self._merge_dict(a._dictionary[key], b._dictionary[key])
             else:
                 a._dictionary[key] = value
@@ -82,7 +82,7 @@ class ConfigTree(object):
         :return:
         """
         tokens = re.findall('"[^"]+"|[^\.]+', str)
-        return map(lambda t: t.strip('"'), tokens)
+        return [t.strip('"') for t in tokens]
 
     def put(self, key, value, append=False):
         """Put a value in the tree (dot separated)
@@ -178,30 +178,6 @@ class ConfigTree(object):
         """
         return self._dictionary.items()
 
-    def iteritems(self):
-        """Return items iterator found in the config
-
-        :return: items iterator
-        :type return: iterator
-        """
-        return self._dictionary.iteritems()
-
-    def iterkeys(self):
-        """Return keys iterator found in the config
-
-        :return: keys iterator
-        :type return: iterator
-        """
-        return self._dictionary.iterkeys()
-
-    def itervalues(self):
-        """Return values iterator found in the config
-
-        :return: values iterator
-        :type return: iterator
-        """
-        return self._dictionary.itervalues()
-
     def __getitem__(self, item):
         val = self.get(item)
         if val is None:
@@ -275,11 +251,11 @@ class ConfigSubstitution(object):
 
 class ConfigUnquotedString(str):
 
-    def __init__(self, value):
-        super(ConfigUnquotedString, self).__init__(value)
+    def __new__(cls, value):
+        return super(ConfigUnquotedString, cls).__new__(cls, value)
 
 
 class ConfigSlashString(str):
 
-    def __init__(self, value):
-        super(ConfigUnquotedString, self).__init__(value)
+    def __new__(cls, value):
+        return super(ConfigSlashString, cls).__new__(cls, value)

--- a/pyhocon/tool.py
+++ b/pyhocon/tool.py
@@ -149,7 +149,7 @@ class HOCONConverter(object):
             raise Exception("Format must be 'json', 'properties' or 'yaml'")
 
         if output_file is None:
-            print res
+            print(res)
         else:
             with open(output_file, "w") as fd:
                 fd.write(res)

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -22,12 +22,13 @@ class TestConfigParser(object):
             }
             """
         )
+
         assert config.get_string('t.c') == '5'
         assert config.get_int('t.c') == 5
         assert config.get('t.e.y.f') == 7
         assert config.get('t.e.y.g') == 'hey dude!'
         assert config.get('t.e.y.h') == 'hey man!'
-        assert map(lambda l: l.strip(), config.get('t.e.y.i').split('\n')) == ['', '"first line"', '"second" line', '']
+        assert [l.strip() for l in config.get('t.e.y.i').split('\n')] == ['', '"first line"', '"second" line', '']
         assert config.get_bool('t.d') is True
         assert config.get_int('t.e.y.f') == 7
         assert config.get('t.j') == [1, 2, 3]

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = pep8, py27
+envlist = pep8, py27, py34
 
 [testenv]
 deps = pytest
-commands = py.test
+commands = py.test {posargs}
 
 [testenv:pep8]
 basepython = python
 deps = pep8
 commands = pep8 pyhocon tests
-


### PR DESCRIPTION
Added changes which make this library Python 2.7 and 3.4 compatible to the extent that is covered by unit tests.

`iter*` methods are removed because there are no `iter*` methods on a dictionary in Python 3.x so there was no trivial solution for compatibility. These methods could have been used by someone for performance reasons, but I believe it is very unlikely, because it is quite cumbersome to access nested values using `iter*` methods.