### PR TITLE
Make ConfigTree subclass OrderedDict

### DIFF
--- a/pyhocon/__init__.py
+++ b/pyhocon/__init__.py
@@ -291,7 +291,7 @@ class ConfigTreeParser(TokenConverter):
         config_tree = ConfigTree()
         for element in token_list:
             # from include then merge items
-            expanded_tokens = element._dictionary.items() if isinstance(element, ConfigTree) else [element]
+            expanded_tokens = element.items() if isinstance(element, ConfigTree) else [element]
 
             for tokens in expanded_tokens:
                 # key, value1, value2, ...

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -170,7 +170,6 @@ class ConfigTree(OrderedDict):
         else:
             raise ConfigException("{key} has type '{type}' rather than 'config'".format(key=key, type=type(value).__name__))
 
-
     def __getitem__(self, item):
         val = self.get(item)
         if val is None:

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -28,11 +28,11 @@ class TestConfigParser(object):
         config_tree = ConfigTree()
         config_tree.put("a.b.c", 5)
         for k in config_tree:
-           assert k == "a"
-           assert config_tree[k]["b.c"] == 5
+            assert k == "a"
+            assert config_tree[k]["b.c"] == 5
 
     def test_config_logging(self):
-        import logging, logging.config
+        import logging.config
         config_tree = ConfigTree()
         config_tree.put('version', 1)
         config_tree.put('root.level', logging.INFO)

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -23,3 +23,18 @@ class TestConfigParser(object):
         config_tree = ConfigTree()
         config_tree.put("a.b.c", 5)
         assert config_tree.get("a.b.c") == 5
+
+    def test_config_tree_iterator(self):
+        config_tree = ConfigTree()
+        config_tree.put("a.b.c", 5)
+        for k in config_tree:
+           assert k == "a"
+           assert config_tree[k]["b.c"] == 5
+
+    def test_config_logging(self):
+        import logging, logging.config
+        config_tree = ConfigTree()
+        config_tree.put('version', 1)
+        config_tree.put('root.level', logging.INFO)
+        assert dict(config_tree)['version'] == 1
+        logging.config.dictConfig(config_tree)


### PR DESCRIPTION
This:
- simplifies the code
- adds useful missing methods e.g. to support iteration
- improves interoperability with other libraries, for example the standard logging lib