### PR TITLE
Fix getting null bug

### DIFF
--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -60,9 +60,9 @@ class ConfigTree(OrderedDict):
 
     def _get(self, key_path, key_index=0):
         key_elt = key_path[key_index]
-        elt = super(ConfigTree, self).get(key_elt)
+        elt = super(ConfigTree, self).get(key_elt, self.UndefinedKey)
 
-        if elt is None:
+        if elt is self.UndefinedKey:
             raise ConfigMissingException("No configuration setting found for key {key}".format(key='.'.join(key_path[:key_index + 1])))
 
         if key_index == len(key_path) - 1:
@@ -172,9 +172,12 @@ class ConfigTree(OrderedDict):
 
     def __getitem__(self, item):
         val = self.get(item)
-        if val is None:
+        if val is self.UndefinedKey:
             raise KeyError(item)
         return val
+
+    class UndefinedKey(object):
+        pass
 
 
 class ConfigList(list):

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -38,3 +38,8 @@ class TestConfigParser(object):
         config_tree.put('root.level', logging.INFO)
         assert dict(config_tree)['version'] == 1
         logging.config.dictConfig(config_tree)
+
+    def test_config_tree_null(self):
+        config_tree = ConfigTree()
+        config_tree.put("a.b.c", None)
+        assert config_tree.get("a.b.c") is None


### PR DESCRIPTION
I tried to parse `./samples/database.conf`, but I got following error.

```python
  File "/usr/local/lib/python2.7/site-packages/pyhocon/config_tree.py", line 66, in _get
    raise ConfigMissingException("No configuration setting found for key {key}".format(key='.'.join(key_path[:key_index + 1])))
pyhocon.exceptions.ConfigMissingException: No configuration setting found for key resolver
```

This exception was raised when ConfigTree's `_get` method get `None` value, regardless of whether undefined key or the hocon setting `key = null`.

So I implemented `UndefinedKey` object instead of `None` when unknown key is specified.