### PR TITLE
Dict assignment fix

### DIFF
--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -280,7 +280,7 @@ class ConfigValues(object):
     def put(self, index, value):
         self.tokens[index] = value
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return '[ConfigValues: ' + ','.join(str(o) for o in self.tokens) + ']'
 
 
@@ -293,7 +293,7 @@ class ConfigSubstitution(object):
         self.instring = instring
         self.loc = loc
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return '[ConfigSubstitution: ' + self.variable + ']'
 
 

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -1,3 +1,6 @@
+from pyparsing import lineno
+from pyparsing import col
+
 try:
     from collections import OrderedDict
 except ImportError:
@@ -49,11 +52,12 @@ class ConfigTree(OrderedDict):
                 elif l is None:
                     self[key_elt] = value
                 else:
-                    raise ConfigWrongTypeException("Cannot concatenate the list {key}: {value} to {prev_value} of {type}".format(
-                        key='.'.join(key_path),
-                        value=value,
-                        prev_value=l,
-                        type=l.__class__.__name__)
+                    raise ConfigWrongTypeException(
+                        "Cannot concatenate the list {key}: {value} to {prev_value} of {type}".format(
+                            key='.'.join(key_path),
+                            value=value,
+                            prev_value=l,
+                            type=l.__class__.__name__)
                     )
             else:
                 super(ConfigTree, self).__setitem__(key_elt, value)
@@ -70,14 +74,17 @@ class ConfigTree(OrderedDict):
         elt = super(ConfigTree, self).get(key_elt, self.UndefinedKey)
 
         if elt is self.UndefinedKey:
-            raise ConfigMissingException("No configuration setting found for key {key}".format(key='.'.join(key_path[:key_index + 1])))
+            raise ConfigMissingException(
+                "No configuration setting found for key {key}".format(key='.'.join(key_path[:key_index + 1])))
 
         if key_index == len(key_path) - 1:
             return elt
         elif isinstance(elt, ConfigTree):
             return elt._get(key_path, key_index + 1)
         else:
-            raise ConfigWrongTypeException("{key} has type {type} rather than dict".format(key='.'.join(key_path[:key_index + 1]), type=type(elt).__name__))
+            raise ConfigWrongTypeException(
+                "{key} has type {type} rather than dict".format(key='.'.join(key_path[:key_index + 1]),
+                                                                type=type(elt).__name__))
 
     def _parse_key(self, str):
         """
@@ -162,7 +169,8 @@ class ConfigTree(OrderedDict):
         if isinstance(value, list):
             return value
         else:
-            raise ConfigException("{key} has type '{type}' rather than 'list'".format(key=key, type=type(value).__name__))
+            raise ConfigException(
+                "{key} has type '{type}' rather than 'list'".format(key=key, type=type(value).__name__))
 
     def get_config(self, key):
         """Return tree config representation of value found at key
@@ -173,10 +181,11 @@ class ConfigTree(OrderedDict):
         :type return: ConfigTree
         """
         value = self.get(key)
-        if isinstance(value, ConfigTree):
+        if isinstance(value, dict):
             return value
         else:
-            raise ConfigException("{key} has type '{type}' rather than 'config'".format(key=key, type=type(value).__name__))
+            raise ConfigException(
+                "{key} has type '{type}' rather than 'config'".format(key=key, type=type(value).__name__))
 
     def __getitem__(self, item):
         val = self.get(item)
@@ -199,10 +208,12 @@ class ConfigList(list):
 
 
 class ConfigValues(object):
-    def __init__(self, iterable):
-        self.tokens = iterable
+    def __init__(self, tokens, instring, loc):
+        self.tokens = tokens
         self.parent = None
         self.key = None
+        self._instring = instring
+        self._loc = loc
 
         for index, token in enumerate(self.tokens):
             if isinstance(token, ConfigSubstitution):
@@ -233,9 +244,14 @@ class ConfigValues(object):
         for index, token in enumerate(self.tokens[1:]):
             tok_type = determine_type(token)
             if first_tok_type is not tok_type:
-                raise ConfigWrongTypeException("Token '{token}' of type {tok_type} (index {index}) must be of type {req_tok_type}".format(
-                    token=token, index=index+1, tok_type=tok_type.__name__, req_tok_type=first_tok_type.__name__)
-                )
+                raise ConfigWrongTypeException(
+                    "Token '{token}' of type {tok_type} (index {index}) must be of type {req_tok_type} (line: {line}, col: {col})".format(
+                        token=token,
+                        index=index + 1,
+                        tok_type=tok_type.__name__,
+                        req_tok_type=first_tok_type.__name__,
+                        line=lineno(self._loc, self._instring),
+                        col=col(self._loc, self._instring)))
 
         if first_tok_type is ConfigTree:
             result = ConfigTree()
@@ -257,7 +273,9 @@ class ConfigValues(object):
             if len(self.tokens) == 1:
                 return self.tokens[0]
             else:
-                return ''.join(token if isinstance(token, str) else str(token) + ' ' for token in self.tokens[:-1]) + str(self.tokens[-1])
+                return ''.join(
+                    token if isinstance(token, str) else str(token) + ' ' for token in self.tokens[:-1]) + str(
+                    self.tokens[-1])
 
     def put(self, index, value):
         self.tokens[index] = value
@@ -267,23 +285,18 @@ class ConfigValues(object):
 
 
 class ConfigSubstitution(object):
-    def __init__(self, variable, ws):
+    def __init__(self, variable, ws, instring, loc):
         self.variable = variable
         self.ws = ws
         self.index = None
         self.parent = None
+        self.instring = instring
+        self.loc = loc
 
     def __repr__(self):
         return '[ConfigSubstitution: ' + self.variable + ']'
 
 
 class ConfigUnquotedString(str):
-
     def __new__(cls, value):
         return super(ConfigUnquotedString, cls).__new__(cls, value)
-
-
-class ConfigSlashString(str):
-
-    def __new__(cls, value):
-        return super(ConfigSlashString, cls).__new__(cls, value)

--- a/pyhocon/tool.py
+++ b/pyhocon/tool.py
@@ -156,7 +156,7 @@ class HOCONConverter(object):
                 fd.write(res)
 
 
-def main():
+def main():  # pragma: no cover
     parser = argparse.ArgumentParser(description='pyhocon tool')
     parser.add_argument('-i', '--input', help='input file')
     parser.add_argument('-o', '--output', help='output file')
@@ -167,5 +167,5 @@ def main():
     HOCONConverter.convert(args.input, args.output, args.format)
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: no cover
     main()

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,3 +1,4 @@
+from pyparsing import ParseSyntaxException, ParseException
 import pytest
 from pyhocon import ConfigFactory, ConfigSubstitutionException
 from pyhocon.exceptions import ConfigMissingException, ConfigWrongTypeException
@@ -606,3 +607,30 @@ class TestConfigParser(object):
         assert config.get('a')[0].get('b') == 2
         assert config.get('a')[1].get('a') == 3
         assert config.get('a')[1].get('c') == 4
+
+    def test_invalid_assignment(self):
+        with pytest.raises(ParseSyntaxException):
+            ConfigFactory.parse_string('common_modules [perl]')
+
+        with pytest.raises(ParseException):
+            ConfigFactory.parse_string('common_modules {} {perl: 1}')
+
+        with pytest.raises(ParseSyntaxException):
+            ConfigFactory.parse_string(
+                """
+                a = {f: 5}
+                common_modules ${a} {perl: 1}
+                """)
+
+    def test_invalid_dict(self):
+        with pytest.raises(ParseSyntaxException):
+            ConfigFactory.parse_string(
+                """
+                a = {
+                    f: 5
+                    g
+                }
+                """)
+
+        with pytest.raises(ParseSyntaxException):
+            ConfigFactory.parse_string('a = {g}')

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -19,6 +19,17 @@ class TestConfigParser(object):
         with pytest.raises(ConfigWrongTypeException):
             config_tree.get("a.b.c.e")
 
+    def test_config_list(self):
+        config_tree = ConfigTree()
+        config_tree.put("a.b.c", [4, 5])
+        assert config_tree.get("a.b.c") == [4, 5]
+
+        config_tree.put("a.b.c", [6, 7])
+        assert config_tree.get("a.b.c") == [6, 7]
+
+        config_tree.put("a.b.c", [8, 9], True)
+        assert config_tree.get("a.b.c") == [6, 7, 8, 9]
+
     def test_config_tree_number(self):
         config_tree = ConfigTree()
         config_tree.put("a.b.c", 5)
@@ -42,3 +53,35 @@ class TestConfigParser(object):
         config_tree = ConfigTree()
         config_tree.put("a.b.c", None)
         assert config_tree.get("a.b.c") is None
+
+    def test_getters(self):
+        config_tree = ConfigTree()
+        config_tree.put("int", 5)
+        assert config_tree["int"] == 5
+        assert config_tree.get("int") == 5
+        assert config_tree.get_int("int") == 5
+
+        config_tree.put("float", 4.5)
+        assert config_tree["float"] == 4.5
+        assert config_tree.get("float") == 4.5
+        assert config_tree.get_float("float") == 4.5
+
+        config_tree.put("string", "string")
+        assert config_tree["string"] == "string"
+        assert config_tree.get("string") == "string"
+        assert config_tree.get_string("string") == "string"
+
+        config_tree.put("list", [1, 2, 3])
+        assert config_tree["list"] == [1, 2, 3]
+        assert config_tree.get("list") == [1, 2, 3]
+        assert config_tree.get_list("list") == [1, 2, 3]
+
+        config_tree.put("bool", True)
+        assert config_tree["bool"] is True
+        assert config_tree.get("bool") is True
+        assert config_tree.get_bool("bool") is True
+
+        config_tree.put("config", {'a': 5})
+        assert config_tree["config"] == {'a': 5}
+        assert config_tree.get("config") == {'a': 5}
+        assert config_tree.get_config("config") == {'a': 5}

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,23 +1,25 @@
+import tempfile
 from pyhocon import ConfigFactory
 from pyhocon.tool import HOCONConverter
 
 
 class TestHOCONConverter(object):
-    CONFIG = ConfigFactory.parse_string(
-        """
+    CONFIG_STRING = """
             a = {b: 1}
             b = [1, 2]
             c = 1
             d = "a"
             e = \"\"\"1
                 2
-            3\"\"\"
+                3\"\"\"
+            f = true
+            g = []
         """
-    )
 
-    def test_to_json(self):
-        expected = \
-            """
+    CONFIG = ConfigFactory.parse_string(CONFIG_STRING)
+
+    EXPECTED_JSON = \
+        """
             {
               "a": {
                 "b": 1
@@ -28,16 +30,14 @@ class TestHOCONConverter(object):
               ],
               "c": 1,
               "d": "a",
-              "e": "1\\n                2\\n            3"
+              "e": "1\\n                2\\n                3",
+              "f": true,
+              "g": []
             }
-            """
+        """
 
-        converted = HOCONConverter.to_json(TestHOCONConverter.CONFIG)
-        assert [line.strip() for line in expected.split('\n') if line.strip()] == [line.strip() for line in converted.split('\n') if line.strip()]
-
-    def test_to_yaml(self):
-        expected = \
-            """
+    EXPECTED_YAML = \
+        """
             a:
               b: 1
             b:
@@ -49,13 +49,12 @@ class TestHOCONConverter(object):
              1
                             2
                         3
-            """
-        converted = HOCONConverter.to_yaml(TestHOCONConverter.CONFIG)
-        assert [line.strip() for line in expected.split('\n') if line.strip()] == [line.strip() for line in converted.split('\n') if line.strip()]
+            f: true
+            g: []
+        """
 
-    def test_to_properties(self):
-        expected = \
-            """
+    EXPECTED_PROPERTIES = \
+        """
             a.b = 1
             b.0 = 1
             b.1 = 2
@@ -64,6 +63,36 @@ class TestHOCONConverter(object):
             e = 1\\
                             2\\
                         3
-            """
+            f = true
+        """
+
+    def test_to_json(self):
+        converted = HOCONConverter.to_json(TestHOCONConverter.CONFIG)
+        assert [line.strip() for line in TestHOCONConverter.EXPECTED_JSON.split('\n') if line.strip()]\
+            == [line.strip() for line in converted.split('\n') if line.strip()]
+
+    def test_to_yaml(self):
+        converted = HOCONConverter.to_yaml(TestHOCONConverter.CONFIG)
+        assert [line.strip() for line in TestHOCONConverter.EXPECTED_YAML.split('\n') if line.strip()]\
+            == [line.strip() for line in converted.split('\n') if line.strip()]
+
+    def test_to_properties(self):
         converted = HOCONConverter.to_properties(TestHOCONConverter.CONFIG)
-        assert [line.strip() for line in expected.split('\n') if line.strip()] == [line.strip() for line in converted.split('\n') if line.strip()]
+        assert [line.strip() for line in TestHOCONConverter.EXPECTED_PROPERTIES.split('\n') if line.strip()]\
+            == [line.strip() for line in converted.split('\n') if line.strip()]
+
+    def _test_convert(self, input, expected_output, format):
+        with tempfile.NamedTemporaryFile('w') as fdin:
+            fdin.write(input)
+            fdin.flush()
+            with tempfile.NamedTemporaryFile('r') as fdout:
+                HOCONConverter.convert(fdin.name, fdout.name, format)
+                with open(fdout.name) as fdi:
+                    converted = fdi.read()
+                    assert [line.strip() for line in expected_output.split('\n') if line.strip()]\
+                        == [line.strip() for line in converted.split('\n') if line.strip()]
+
+    def test_convert(self):
+        self._test_convert(TestHOCONConverter.CONFIG_STRING, TestHOCONConverter.EXPECTED_JSON, 'json')
+        self._test_convert(TestHOCONConverter.CONFIG_STRING, TestHOCONConverter.EXPECTED_YAML, 'yaml')
+        self._test_convert(TestHOCONConverter.CONFIG_STRING, TestHOCONConverter.EXPECTED_PROPERTIES, 'properties')

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,4 +1,5 @@
 import tempfile
+import pytest
 from pyhocon import ConfigFactory
 from pyhocon.tool import HOCONConverter
 
@@ -14,6 +15,8 @@ class TestHOCONConverter(object):
                 3\"\"\"
             f = true
             g = []
+            h = null
+            i = {}
         """
 
     CONFIG = ConfigFactory.parse_string(CONFIG_STRING)
@@ -32,7 +35,9 @@ class TestHOCONConverter(object):
               "d": "a",
               "e": "1\\n                2\\n                3",
               "f": true,
-              "g": []
+              "g": [],
+              "h": null,
+              "i": {}
             }
         """
 
@@ -51,6 +56,8 @@ class TestHOCONConverter(object):
                         3
             f: true
             g: []
+            h: None
+            i:
         """
 
     EXPECTED_PROPERTIES = \
@@ -96,3 +103,7 @@ class TestHOCONConverter(object):
         self._test_convert(TestHOCONConverter.CONFIG_STRING, TestHOCONConverter.EXPECTED_JSON, 'json')
         self._test_convert(TestHOCONConverter.CONFIG_STRING, TestHOCONConverter.EXPECTED_YAML, 'yaml')
         self._test_convert(TestHOCONConverter.CONFIG_STRING, TestHOCONConverter.EXPECTED_PROPERTIES, 'properties')
+
+    def test_invalid_format(self):
+        with pytest.raises(Exception):
+            self._test_convert(TestHOCONConverter.CONFIG_STRING, TestHOCONConverter.EXPECTED_PROPERTIES, 'invalid')


### PR DESCRIPTION
these expressions should be considered as invalid
```
d [5]
d {f: 5} {}
d ${a}
```

but the followings are valid:
```
d {
  f: 5
}

e {}
```