### PR TITLE
Resolve substitutions only after all files have been loaded.

### DIFF
--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -773,6 +773,21 @@ class TestConfigParser(object):
             )
             assert config3['a'] == expected_res
 
+
+    def test_include_substitution(self):
+        with tempfile.NamedTemporaryFile('w') as fdin:
+            fdin.write('y = ${x}')
+            fdin.flush()
+
+            config = ConfigFactory.parse_string(
+                """
+                include "{tmp_file}"
+                x = 42
+                """.format(tmp_file=fdin.name)
+            )
+            assert config['x'] == 42
+            assert config['y'] == 42
+
     def test_substitution_override(self):
         config = ConfigFactory.parse_string(
             """


### PR DESCRIPTION
This allows included files to properly reference keys that are defined
in an including file. From the HOCON spec:

    Substitution processing is performed as the last parsing step, so a
    substitution can look forward in the configuration. If a
    configuration consists of multiple files, it may even end up
    retrieving a value from another file.

This change has the possibility of breaking configuration files. For
example:

foo.conf:

    { x: 10, y: ${x} }

bar.conf:

    include "foo.conf"
    x: 42

Prior to this change, the output of pyhocon is:

    {
      "x": 42,
      "y": 10
    }

because the value of `y` is looked up immediately after `foo.conf` is
parsed.

After this change, the output of pyhocon is:

    {
      "x": 42,
      "y": 42
    }

This matches what the reference java implementation produces.

This change does not address "fixing up" as described in
https://github.com/typesafehub/config/blob/master/HOCON.md#include-semantics-substitution