### PR TITLE
added from_dict method

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -83,6 +83,16 @@ class ConfigFactory(object):
         """
         return ConfigParser().parse(content, basedir, resolve)
 
+    @staticmethod
+    def from_dict(dictionary):
+        """Convert dictionary (and ordered dictionary) into a ConfigTree
+        :param dictionary: dictionary to convert
+        :type dictionary: dict
+        :return: Config object
+        :type return: Config
+        """
+        return ConfigTree(dictionary)
+
 
 class ConfigParser(object):
     """

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -18,6 +18,7 @@ class ConfigTree(OrderedDict):
 
     def __init__(self, *args, **kwds):
         super(ConfigTree, self).__init__(*args, **kwds)
+
         for key, value in self.items():
             if isinstance(value, ConfigValues):
                 value.parent = self

--- a/pyhocon/tool.py
+++ b/pyhocon/tool.py
@@ -9,6 +9,7 @@ LOG_FORMAT = '%(asctime)s %(levelname)s: %(message)s'
 
 
 class HOCONConverter(object):
+
     @staticmethod
     def to_json(config, indent=2, level=0):
         """Convert HOCON input into a JSON output

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import tempfile
 from pyparsing import ParseSyntaxException, ParseException
 import pytest
@@ -1143,3 +1144,22 @@ with-escaped-newline-escape-sequence: \"\"\"
         assert config['with-escaped-backslash'] == '\n\\\\\n'
         assert config['with-newline-escape-sequence'] == '\n\\n\n'
         assert config['with-escaped-newline-escape-sequence'] == '\n\\\\n\n'
+
+    def test_from_dict_with_dict(self):
+        d = {
+            'banana': 3,
+            'apple': 4,
+            'pear': 1,
+            'orange': 2,
+        }
+        config = ConfigFactory.from_dict(d)
+        assert config == d
+
+    def test_from_dict_with_ordered_dict(self):
+        d = OrderedDict()
+        d['banana'] = 3
+        d['apple'] = 4
+        d['pear'] = 1
+        d['orange'] = 2
+        config = ConfigFactory.from_dict(d)
+        assert config == d

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,9 +1,12 @@
-from collections import OrderedDict
 import tempfile
 from pyparsing import ParseSyntaxException, ParseException
 import pytest
 from pyhocon import ConfigFactory, ConfigSubstitutionException
 from pyhocon.exceptions import ConfigMissingException, ConfigWrongTypeException
+try:  # pragma: no cover
+    from collections import OrderedDict
+except ImportError:  # pragma: no cover
+    from ordereddict import OrderedDict
 
 
 class TestConfigParser(object):


### PR DESCRIPTION
This should resolve #39 
```
        d = OrderedDict()
        d['banana'] = 3
        d['apple'] = 4
        d['pear'] = 1
        d['orange'] = 2
        config = ConfigFactory.from_dict(d)
        assert config == d
or:
        d = {
            'banana': 3,
            'apple': 4,
            'pear': 1,
            'orange': 2,
        }
        config = ConfigFactory.from_dict(d)
        assert config == d

```