### PR TITLE
fixed string instance check in with_fallback method (Issue #44)

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -20,6 +20,10 @@ except ImportError:
     from urllib2 import urlopen, HTTPError
 
     use_urllib2 = True
+try:
+    basestring
+except NameError:
+    basestring = str
 
 
 logger = logging.getLogger(__name__)
@@ -315,7 +319,7 @@ class ConfigParser(object):
                         # if it is a string, then add the extra ws that was present in the original string after the substitution
                         formatted_resolved_value = \
                             resolved_value + substitution.ws \
-                            if isinstance(resolved_value, str) and substitution.index < len(config_values.tokens) - 1 else resolved_value
+                            if isinstance(resolved_value, basestring) and substitution.index < len(config_values.tokens) - 1 else resolved_value
                         config_values.put(substitution.index, formatted_resolved_value)
                         transformation = config_values.transform()
                         if transformation is None and not is_optional_resolved:

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -233,11 +233,11 @@ class ConfigTree(OrderedDict):
         :param config: config or filename of the config to fallback on
         :return: new config with fallback on config
         """
-        if isinstance(config, str):
+        if isinstance(config, ConfigTree):
+            result = self._merge_config_tree(config, self)
+        else:
             from . import ConfigFactory
             result = self._merge_config_tree(ConfigFactory.parse_file(config, resolve=False), self)
-        else:
-            result = self._merge_config_tree(config, self)
 
         from . import ConfigParser
         ConfigParser.resolve_substitutions(result)

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -5,6 +5,11 @@ try:  # pragma: no cover
     from collections import OrderedDict
 except ImportError:  # pragma: no cover
     from ordereddict import OrderedDict
+try:
+    basestring
+except NameError:
+    basestring = str
+
 import re
 from .exceptions import ConfigException, ConfigWrongTypeException, ConfigMissingException
 
@@ -343,7 +348,7 @@ class ConfigValues(object):
                 return tokens[0]
             else:
                 return ''.join(
-                    token if isinstance(token, str) else format_str(token) + ' ' for token in tokens[:-1]) + format_str(tokens[-1])
+                    token if isinstance(token, basestring) else format_str(token) + ' ' for token in tokens[:-1]) + format_str(tokens[-1])
 
     def put(self, index, value):
         self.tokens[index] = value

--- a/pyhocon/tool.py
+++ b/pyhocon/tool.py
@@ -4,6 +4,11 @@ import sys
 from pyhocon import ConfigFactory
 from pyhocon.config_tree import ConfigTree
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
 
 LOG_FORMAT = '%(asctime)s %(levelname)s: %(message)s'
 
@@ -45,7 +50,7 @@ class HOCONConverter(object):
                     )
                 lines += ',\n'.join(bet_lines)
                 lines += '\n{indent}]'.format(indent=''.rjust(level * indent, ' '))
-        elif isinstance(config, str):
+        elif isinstance(config, basestring):
             lines = '"{value}"'.format(value=config.replace('\n', '\\n').replace('"', '\\"'))
         elif config is None:
             lines = 'null'
@@ -93,7 +98,7 @@ class HOCONConverter(object):
                     bet_lines.append('{indent}{value}'.format(indent=''.rjust(level * indent, ' '), value=HOCONConverter.to_hocon(item, indent, level + 1)))
                 lines += '\n'.join(bet_lines)
                 lines += '\n{indent}]'.format(indent=''.rjust((level - 1) * indent, ' '))
-        elif isinstance(config, str):
+        elif isinstance(config, basestring):
             if '\n' in config:
                 lines = '"""{value}"""'.format(value=config)  # multilines
             else:
@@ -138,7 +143,7 @@ class HOCONConverter(object):
                 for item in config_list:
                     bet_lines.append('{indent}- {value}'.format(indent=''.rjust(level * indent, ' '), value=HOCONConverter.to_yaml(item, indent, level + 1)))
                 lines += '\n'.join(bet_lines)
-        elif isinstance(config, str):
+        elif isinstance(config, basestring):
             # if it contains a \n then it's multiline
             lines = config.split('\n')
             if len(lines) == 1:
@@ -174,7 +179,7 @@ class HOCONConverter(object):
             for index, item in enumerate(config):
                 if item is not None:
                     lines.append(HOCONConverter.to_properties(item, indent, stripped_key_stack + [str(index)]))
-        elif isinstance(config, str):
+        elif isinstance(config, basestring):
             lines.append('.'.join(stripped_key_stack) + ' = ' + escape_value(config))
         elif config is True:
             lines.append('.'.join(stripped_key_stack) + ' = true')

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -314,7 +314,7 @@ class TestConfigParser(object):
         assert config2.get('f') == 'test  str      '
 
         config3 = ConfigFactory.parse_string(
-            """
+            u"""
             {
                 a: {
                     b: {

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1087,7 +1087,7 @@ class TestConfigParser(object):
         )
 
         config5 = ConfigFactory.parse_string(
-            """
+            u"""
             longName: "long "${?name}
             """,
             resolve=False

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1109,7 +1109,8 @@ class TestConfigParser(object):
             """
         )
 
-        config2 = config1.with_fallback('samples/aws.conf')
+        # use unicode path here for regression testing https://github.com/chimpler/pyhocon/issues/44
+        config2 = config1.with_fallback(u'samples/aws.conf')
         assert config2 == {
             'data-center-generic': {'cluster-size': 8},
             'data-center-east': {'cluster-size': 8, 'name': 'east'},

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -5,7 +5,7 @@ from pyhocon.tool import HOCONConverter
 
 
 class TestHOCONConverter(object):
-    CONFIG_STRING = """
+    CONFIG_STRING = u"""
             a = {b: 1}
             b = [1, 2]
             c = 1


### PR DESCRIPTION
I changed the input path in the test to a unicode string which reproduced the bug for 2.x interpreters. As a fix I flipped the instance check condition around.

Out of curiosity I tried unicode string in other places and found more issues. I will try to fix those as well and report back soon.