### PR TITLE
Fixed command line option parsing to use a default indent of 2.

### DIFF
--- a/pyhocon/tool.py
+++ b/pyhocon/tool.py
@@ -232,7 +232,7 @@ def main():  # pragma: no cover
     parser.add_argument('-i', '--input', help='input file')
     parser.add_argument('-o', '--output', help='output file')
     parser.add_argument('-f', '--format', help='output format: json, properties, yaml or hocon', default='json')
-    parser.add_argument('-n', '--indent', help='indentation step (default is 2)', type=int)
+    parser.add_argument('-n', '--indent', help='indentation step (default is 2)', default=2, type=int)
     parser.add_argument('-v', '--verbosity', action='count', default=0, help='Increase output verbosity')
     args = parser.parse_args()
 


### PR DESCRIPTION
Previously the example usage of the tool in README.md would generate errors.
This trivial change removes those issues.

This was initially introduced in revision e7a6184