### PR TITLE
Adding argparse as a dependency if being installed on Python 2.6.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from setuptools.command.test import test as TestCommand
 
 required_packages = ['pyparsing==2.0.3']
 if sys.version_info[:2] == (2, 6):
+    required_packages.append('argparse')
     required_packages.append('ordereddict')
 
 


### PR DESCRIPTION
Solves #53