### PR TITLE
Nested substitution fails and it's wrongly detected as a cycle

### DIFF
--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1261,6 +1261,21 @@ class TestConfigParser(object):
             'large-jvm-opts': ['-XX:+UseParNewGC', '-Xm16g']
         }
 
+    def test_object_field_substitution(self):
+        config = ConfigFactory.parse_string(
+            """
+            A = ${Test}
+
+            Test {
+                field1 = 1
+                field2 = ${Test.field1}"2"
+                field3 = ${Test.field2}"3"
+            }
+            """
+        )
+
+        assert config.get_string("Test.field3") == "123"
+
     def test_one_line_quote_escape(self):
         config = ConfigFactory.parse_string(
             """


### PR DESCRIPTION
The test in this PR highlights the issue; there's no cycle involved, but resolve_substitutions fails nevertheless.

Running this test with `py.test -k test_object_field_substitution` yields:

```
    @staticmethod
    def resolve_substitutions(config):
        # traverse config to find all the substitutions
        def find_substitutions(item):
....
            if unresolved:
                raise ConfigSubstitutionException("Cannot resolve {variables}. Check for cycles.".format(
                    variables=', '.join('${{{variable}}}: (line: {line}, col: {col})'.format(
                        variable=substitution.variable,
                        line=lineno(substitution.loc, substitution.instring),
>                       col=col(substitution.loc, substitution.instring)) for substitution in _substitutions)))
E               ConfigSubstitutionException: Cannot resolve ${Test.field2}: (line: 9, col: 26). Check for cycles.

```