### PR TITLE
handle unreachable URL include

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -14,10 +14,10 @@ use_urllib2 = False
 try:
     # For Python 3.0 and later
     from urllib.request import urlopen
-    from urllib.error import HTTPError
+    from urllib.error import HTTPError, URLError
 except ImportError:
     # Fall back to Python 2's urllib2
-    from urllib2 import urlopen, HTTPError
+    from urllib2 import urlopen, HTTPError, URLError
 
     use_urllib2 = True
 try:
@@ -69,7 +69,7 @@ class ConfigFactory(object):
             with contextlib.closing(urlopen(url, timeout=socket_timeout)) as fd:
                 content = fd.read() if use_urllib2 else fd.read().decode('utf-8')
                 return ConfigFactory.parse_string(content, os.path.dirname(url), resolve)
-        except HTTPError:
+        except (HTTPError, URLError):
             logger.warn('Cannot include url %s. Resource is inaccessible.', url)
             return []
 

--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -60,8 +60,8 @@ class ConfigFactory(object):
         :type url: basestring
         :param resolve: If true, resolve substitutions
         :type resolve: boolean
-        :return: Config object
-        :type return: Config
+        :return: Config object or []
+        :type return: Config or list
         """
         socket_timeout = socket._GLOBAL_DEFAULT_TIMEOUT if timeout is None else timeout
 

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -744,6 +744,10 @@ class TestConfigParser(object):
         assert config.get('data-center-generic.cluster-size') == 6
         assert config.get('large-jvm-opts') == ['-XX:+UseParNewGC', '-Xm16g']
 
+    def test_parse_URL_from_invalid(self):
+        config = ConfigFactory.parse_URL("https://nosuchurl")
+        assert config == []
+
     def test_include_dict_from_samples(self):
         config = ConfigFactory.parse_file("samples/animals.conf")
         assert config.get('cat.garfield.say') == 'meow'


### PR DESCRIPTION
Fixes following error when trying to include an unreadable or invalid URL:

```
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pyhocon/config_parser.py", line 185, in include_config
    obj = ConfigFactory.parse_URL(url, resolve=False)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pyhocon/config_parser.py", line 73, in parse_URL
    fd.close()
UnboundLocalError: local variable 'fd' referenced before assignment
```