### PR TITLE
Use recursive merging when concatenating objects

### DIFF
--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1354,3 +1354,28 @@ with-escaped-newline-escape-sequence: \"\"\"
         }
         config = ConfigFactory.from_dict(d)
         assert config == d
+
+    def test_object_concat(self):
+        config = ConfigFactory.parse_string(
+            """o1 = {
+                foo : {
+                    a : 1
+                    b : 2
+                }
+            }
+            o2 = {
+                foo : {
+                    b : 3
+                    c : 4
+                }
+            }
+            o3 = ${o1} ${o2}
+            """
+        )
+
+        assert config.get_int('o1.foo.b') == 2
+        assert config.get_int('o2.foo.b') == 3
+        assert config.get_int('o3.foo.b') == 3
+        assert config.get_int('o1.foo.c', default=42) == 42
+        assert config.get_int('o3.foo.a') == 1
+        assert config.get_int('o3.foo.c') == 4


### PR DESCRIPTION
The [doc](https://github.com/typesafehub/config/blob/master/HOCON.md#array-and-object-concatenation) says:

> For objects, "concatenation" means "merging", so the second object overrides the first.

My understanding is that this refers to the [Duplicate keys and object merging](https://github.com/typesafehub/config/blob/master/HOCON.md#duplicate-keys-and-object-merging) section in the documentation, which requires recursive merging of objects.

My [experiments](https://gist.github.com/gilles-duboscq/06846f931c3eedd45ab81ec6fb1bb1f1) with the Java version also seem to support this interpretation of the specs.