### PR TITLE
`ConfigValue.transform`: do not wrap lists

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -368,9 +368,8 @@ class ConfigParser(object):
                                     substitutions.extend(s)
                                     unresolved = True
                         else:
-                            result = transformation[0] if isinstance(transformation, list) else transformation
-                            config_values.parent[config_values.key] = result
-                            s = find_substitutions(result)
+                            config_values.parent[config_values.key] = transformation
+                            s = find_substitutions(transformation)
                             if s:
                                 substitutions.extend(s)
                                 unresolved = True
@@ -418,7 +417,7 @@ class ConcatenatedValueParser(TokenConverter):
 
     def postParse(self, instring, loc, token_list):
         config_values = ConfigValues(token_list, instring, loc)
-        return config_values.transform()
+        return [config_values.transform()]
 
 
 class ConfigTreeParser(TokenConverter):

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -360,7 +360,7 @@ class ConfigValues(object):
                     main_index += 1
                     sublist_result.append(token)
                 result.extend(sublist_result)
-            return [result]
+            return result
         else:
             if len(tokens) == 1:
                 return tokens[0]

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1383,3 +1383,21 @@ with-escaped-newline-escape-sequence: \"\"\"
         assert config.get_int('o1.foo.c', default=42) == 42
         assert config.get_int('o3.foo.a') == 1
         assert config.get_int('o3.foo.c') == 4
+
+    def test_issue_75(self):
+        config = ConfigFactory.parse_string(
+            """base : {
+              bar: ["a"]
+            }
+
+            sub : ${base} {
+              baz: ${base.bar} ["b"]
+            }
+
+            sub2: ${sub}
+            """
+        )
+
+        assert config.get_list('base.bar') == ["a"]
+        assert config.get_list('sub.baz') == ["a", "b"]
+        assert config.get_list('sub2.baz') == ["a", "b"]


### PR DESCRIPTION
Fix for #75:
Move wrapping to `ConcatenatedValueParser`.
Previous behaviour could lead to incorrect double nesting of lists when `transform`ing during `final_fixup`.