### PR TITLE
Key with dots

### DIFF
--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -314,10 +314,7 @@ class ConfigTree(OrderedDict):
                     raise ConfigException("The config tree contains unresolved elements")
                 return v
 
-        plain = OrderedDict()
-        for key, value in self.items():
-            plain[key.strip('"')] = plain_value(value)
-        return plain
+        return OrderedDict((key.strip('"'), plain_value(value)) for key, value in self.items())
 
 
 class ConfigList(list):

--- a/pyhocon/tool.py
+++ b/pyhocon/tool.py
@@ -80,7 +80,7 @@ class HOCONConverter(object):
                 for key, item in config.items():
                     bet_lines.append('{indent}{key}{assign_sign} {value}'.format(
                         indent=''.rjust(level * indent, ' '),
-                        key=key.strip('"'),  # for dotted keys enclosed with "" to not be interpreted as nested key,
+                        key=key,
                         assign_sign='' if isinstance(item, dict) else ' =',
                         value=HOCONConverter.to_hocon(item, indent, level + 1))
                     )

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -2,7 +2,7 @@ import tempfile
 from pyparsing import ParseSyntaxException, ParseException
 import pytest
 from pyhocon import ConfigFactory, ConfigSubstitutionException, ConfigTree, ConfigParser
-from pyhocon.exceptions import ConfigMissingException, ConfigWrongTypeException
+from pyhocon.exceptions import ConfigMissingException, ConfigWrongTypeException, ConfigException
 
 try:  # pragma: no cover
     from collections import OrderedDict
@@ -1753,3 +1753,14 @@ with-escaped-newline-escape-sequence: \"\"\"
         assert config.get_list('base.bar') == ["a"]
         assert config.get_list('sub.baz') == ["a", "b"]
         assert config.get_list('sub2.baz') == ["a", "b"]
+
+    def test_plain_ordered_dict(self):
+        config = ConfigFactory.parse_string(
+            """
+            e : ${a} {
+            }
+            """,
+            resolve=False
+        )
+        with pytest.raises(ConfigException):
+            config.as_plain_ordered_dict()

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -2,6 +2,11 @@ import pytest
 from pyhocon.config_tree import ConfigTree
 from pyhocon.exceptions import ConfigMissingException, ConfigWrongTypeException
 
+try:  # pragma: no cover
+    from collections import OrderedDict
+except ImportError:  # pragma: no cover
+    from ordereddict import OrderedDict
+
 
 class TestConfigParser(object):
 
@@ -140,3 +145,15 @@ class TestConfigParser(object):
         config_tree.put("int", 5, True)
         config_tree.put("int.config", 1, True)
         assert config_tree == {'int': {'config': 1}}
+
+    def test_plain_ordered_dict(self):
+        config_tree = ConfigTree()
+        config_tree.put('"a.b"', 5)
+        config_tree.put('a."b.c"', [ConfigTree(), 2])
+        config_tree.get('a."b.c"')[0].put('"c.d"', 1)
+        d = OrderedDict()
+        d['a.b'] = 5
+        d['a'] = OrderedDict()
+        d['a']['b.c'] = [OrderedDict(), 2]
+        d['a']['b.c'][0]['c.d'] = 1
+        assert config_tree.as_plain_ordered_dict() == d

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -18,6 +18,7 @@ class TestHOCONConverter(object):
             g = []
             h = null
             i = {}
+            "a.b" = 2
         """
 
     CONFIG = ConfigFactory.parse_string(CONFIG_STRING)
@@ -39,7 +40,8 @@ class TestHOCONConverter(object):
               "f2": false,
               "g": [],
               "h": null,
-              "i": {}
+              "i": {},
+              "a.b": 2
             }
         """
 
@@ -60,6 +62,7 @@ class TestHOCONConverter(object):
               g = []
               h = null
               i {}
+              "a.b" = 2
         """
 
     EXPECTED_YAML = \
@@ -80,6 +83,7 @@ class TestHOCONConverter(object):
             g: []
             h: None
             i:
+            a.b: 2
         """
 
     EXPECTED_PROPERTIES = \
@@ -94,6 +98,7 @@ class TestHOCONConverter(object):
                         3
             f1 = true
             f2 = false
+            a.b = 2
         """
 
     def test_to_json(self):


### PR DESCRIPTION
This fixes conversion to HOCON where keys containing dots would not be quoted.

It also add a `ConfigTree.as_plain_ordered_dict` method. The goal there is to easily get an `OrderedDict` with no special behaviour for `__getitem__` and plain keys (not quoted when they contain a `.`). This helps when passing the tree to some code that doesn't expect special cases for `.` in keys.