### PR TITLE
Don't lock pyparsing to a specific version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
-required_packages = ['pyparsing==2.1.1']
+required_packages = ['pyparsing>=2.0.3']
 if sys.version_info[:2] == (2, 6):
     required_packages.append('argparse')
     required_packages.append('ordereddict')


### PR DESCRIPTION
We keep getting dependency issues because some people will upgrade their pyparsing version and pyhocon blows up. I ran the tests on pyparsing 2.1.4 and 2.0.3 and it still works so there is no reason to lock the requirement to 2.1.1. Assuming pyparsing follows semantic versioning properly we should be good.