### PR TITLE
Bug fix for ConfigTree.get_bool()

### DIFF
--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -199,7 +199,10 @@ class ConfigTree(OrderedDict):
         :return: string value
         :type return: basestring
         """
-        return str(self.get(key, default))
+        string_value = str(self.get(key, default))
+        if string_value in ['True', 'False']:
+            return string_value.lower()
+        return string_value
 
     def get_int(self, key, default=UndefinedKey):
         """Return int representation of value found at key
@@ -235,7 +238,18 @@ class ConfigTree(OrderedDict):
         :return: boolean value
         :type return: bool
         """
-        return bool(self.get(key, default))
+
+        # String conversions as per API-recommendations:
+        # https://github.com/typesafehub/config/blob/master/HOCON.md#automatic-type-conversions
+        bool_conversions = {
+            'true': True, 'yes': True, 'on': True,
+            'false': False, 'no': False, 'off': False
+        }
+        try:
+            return bool_conversions[self.get_string(key, default)]
+        except KeyError:
+            raise ConfigException(
+                "{key} does not translate to a Boolean value".format(key=key))
 
     def get_list(self, key, default=UndefinedKey):
         """Return list representation of value found at key

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ class PyTestCommand(TestCommand):
 
 setup(
     name='pyhocon',
-    version='0.3.30',
+    version='0.3.29',
     description='HOCON parser for Python',
     long_description='pyhocon is a HOCON parser for Python. Additionally we provide a tool (pyhocon) to convert any HOCON '
                      'content into json, yaml and properties format.',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ class PyTestCommand(TestCommand):
 
 setup(
     name='pyhocon',
-    version='0.3.29',
+    version='0.3.30',
     description='HOCON parser for Python',
     long_description='pyhocon is a HOCON parser for Python. Additionally we provide a tool (pyhocon) to convert any HOCON '
                      'content into json, yaml and properties format.',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'pyhocon',
     ],
     install_requires=required_packages,
-    tests_require=['pytest'],
+    tests_require=['pytest', 'mock'],
     entry_points={
         'console_scripts': [
             'pyhocon=pyhocon.tool:main'

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1855,10 +1855,10 @@ test2 = test
         assert config == {
             'bool_from_env': 'false'
         }
-        assert config.get_bool('bool_from_env') == False
+        assert config.get_bool('bool_from_env') is False
 
     @mock.patch.dict(os.environ, INT_VAR='5')
-    def test_bool_from_environment(self):
+    def test_int_from_environment(self):
         config = ConfigFactory.parse_string(
             """
             int_from_env = ${INT_VAR}

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,3 +1,5 @@
+import os
+import mock
 import tempfile
 from pyparsing import ParseSyntaxException, ParseException
 import pytest
@@ -1833,3 +1835,35 @@ test2 = test
             'a': 'abc',
             'c': 5
         }
+
+    @mock.patch.dict(os.environ, STRING_VAR='value_from_environment')
+    def test_string_from_environment(self):
+        config = ConfigFactory.parse_string(
+            """
+            string_from_env = ${STRING_VAR}
+            """)
+        assert config == {
+            'string_from_env': 'value_from_environment'
+        }
+
+    @mock.patch.dict(os.environ, TRUE_OR_FALSE='false')
+    def test_bool_from_environment(self):
+        config = ConfigFactory.parse_string(
+            """
+            bool_from_env = ${TRUE_OR_FALSE}
+            """)
+        assert config == {
+            'bool_from_env': 'false'
+        }
+        assert config.get_bool('bool_from_env') == False
+
+    @mock.patch.dict(os.environ, INT_VAR='5')
+    def test_bool_from_environment(self):
+        config = ConfigFactory.parse_string(
+            """
+            int_from_env = ${INT_VAR}
+            """)
+        assert config == {
+            'int_from_env': '5'
+        }
+        assert config.get_int('int_from_env') == 5

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -1,6 +1,7 @@
 import pytest
 from pyhocon.config_tree import ConfigTree
-from pyhocon.exceptions import ConfigMissingException, ConfigWrongTypeException
+from pyhocon.exceptions import (
+    ConfigMissingException, ConfigWrongTypeException, ConfigException)
 
 try:  # pragma: no cover
     from collections import OrderedDict
@@ -133,6 +134,46 @@ class TestConfigParser(object):
         assert config_tree.get("config-new", {'b': 1}) == {'b': 1}
         assert config_tree.get_config("config", {'b': 1}) == {'a': 5}
         assert config_tree.get_config("config-new", {'b': 1}) == {'b': 1}
+
+    def test_getter_type_conversion_string_to_bool(self):
+        config_tree = ConfigTree()
+        config_tree.put("bool-string-true", "true")
+        assert config_tree.get_bool("bool-string-true") is True
+
+        config_tree.put("bool-string-false", "false")
+        assert config_tree.get_bool("bool-string-false") is False
+
+        config_tree.put("bool-string-yes", "yes")
+        assert config_tree.get_bool("bool-string-yes") is True
+
+        config_tree.put("bool-string-no", "no")
+        assert config_tree.get_bool("bool-string-no") is False
+
+        config_tree.put("bool-string-on", "on")
+        assert config_tree.get_bool("bool-string-on") is True
+
+        config_tree.put("bool-string-off", "off")
+        assert config_tree.get_bool("bool-string-off") is False
+
+        config_tree.put("invalid-bool-string", "invalid")
+        with pytest.raises(ConfigException):
+            config_tree.get_bool("invalid-bool-string")
+
+    def test_getter_type_conversion_bool_to_string(self):
+        config_tree = ConfigTree()
+        config_tree.put("bool-true", True)
+        assert config_tree.get_string("bool-true") == "true"
+
+        config_tree.put("bool-false", False)
+        assert config_tree.get_string("bool-false") == "false"
+
+    def test_getter_type_conversion_number_to_string(self):
+        config_tree = ConfigTree()
+        config_tree.put("int", 5)
+        assert config_tree.get_string("int") == "5"
+
+        config_tree.put("float", 2.345)
+        assert config_tree.get_string("float") == "2.345"
 
     def test_overrides_int_with_config_no_append(self):
         config_tree = ConfigTree()


### PR DESCRIPTION
Changes the behavior of `ConfigTree.get_boo()` to adhere to the HOCON API recommendations.
Ensures that Boolean values can be read from the environment.

* Correcting str<->bool conversion logic
* Unit tests for str<->bool conversion logic
* Parser level unit test for reading environment variables
* Bumped version (patch)