### PR TITLE
Fixed Python 2.6 incompatible format string

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -506,7 +506,7 @@ class ConfigTreeParser(TokenConverter):
                 elif len(tokens) == 2:
                     values = tokens[1:]
                 else:
-                    raise ParseSyntaxException("Unknown tokens {} received".format(tokens))
+                    raise ParseSyntaxException("Unknown tokens {tokens} received".format(tokens=tokens))
                 # empty string
                 if len(values) == 0:
                     config_tree.put(key, '')


### PR DESCRIPTION
pyhocon officially supports Python 2.6, so it can't use the {} syntax in format strings ([which was added in 2.7](https://docs.python.org/2/library/string.html#format-string-syntax)). This is the only instance in the code.

Admittedly, I don't know what input would hit this case, so I cannot create a test case for it (It is one of the few lines not currently in the code coverage).