### PR TITLE
Removed dead code

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -297,14 +297,6 @@ class ConfigParser(object):
                             variable=variable,
                             line=lineno(substitution.loc, substitution.instring),
                             col=col(substitution.loc, substitution.instring)))
-            elif isinstance(value, ConfigList) or isinstance(value, ConfigTree):
-                raise ConfigSubstitutionException(
-                    "Cannot substitute variable ${{{variable}}} because it does not point to a "
-                    "string, int, float, boolean or null {type} (line:{line}, col: {col})".format(
-                        variable=variable,
-                        type=value.__class__.__name__,
-                        line=lineno(substitution.loc, substitution.instring),
-                        col=col(substitution.loc, substitution.instring)))
             return True, value
 
     @staticmethod


### PR DESCRIPTION
Unless I'm mistaken, there is no way that `value` can be an instance of ConfigList or ConfigTree.

`ConfigList` is a subclass of `list`, `ConfigTree` is a subclass of `OrderedDict`.
There are no assignments to `os.environ`, nor can these types be assigned to `os.environ` anyway.

See http://stackoverflow.com/questions/39949587/can-python-os-environ-get-ever-return-a-non-string for a discussion.