### PR TITLE
Added pop() method to ConfigTree and added KeyError to ConfigMissingException

### DIFF
--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -204,6 +204,34 @@ class ConfigTree(OrderedDict):
             return string_value.lower()
         return string_value
 
+    def pop(self, key, default=UndefinedKey):
+        """Remove specified key and return the corresponding value.
+        If key is not found, default is returned if given, otherwise ConfigMissingException is raised
+
+        This method assumes the user wants to remove the last value in the chain so it parses via parse_key
+        and pops the last value out of the dict.
+
+        :param key: key to use (dot separated). E.g., a.b.c
+        :type key: basestring
+        :param default: default value if key not found
+        :type default: object
+        :param default: default value if key not found
+        :return: value in the tree located at key
+        """
+        value = self.get(key, default)
+        if value == default:
+            return default
+
+        lst = ConfigTree.parse_key(key)
+        parent = self.KEY_SEP.join(lst[0:-1])
+        child = lst[-1]
+
+        if parent:
+            self.get(parent).__delitem__(child)
+        else:
+            self.__delitem__(child)
+        return value
+
     def get_int(self, key, default=UndefinedKey):
         """Return int representation of value found at key
 

--- a/pyhocon/exceptions.py
+++ b/pyhocon/exceptions.py
@@ -5,7 +5,7 @@ class ConfigException(Exception):
         self._exception = ex
 
 
-class ConfigMissingException(ConfigException):
+class ConfigMissingException(ConfigException, KeyError):
     pass
 
 

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -254,7 +254,7 @@ class TestConfigParser(object):
         exp['f.k']['g']['three'] = 3
 
         assert config_tree.pop('a.b.c').as_plain_ordered_dict() == exp['a']['b']['c']
-        assert config_tree.pop('a.b.c', None) == None
+        assert config_tree.pop('a.b.c', None) is None
 
         with pytest.raises(ConfigMissingException):
             assert config_tree.pop('a.b.c')


### PR DESCRIPTION
Hi there,

I've added a pop() method to the ConfigTree class, and I'm 99% sure that I've done it correctly.  Wanted to submit a pull request so that I don't have to keep patching locally.  :-)  I tried to cover all the edge cases in the test case, but I may have miss something.

Additionally, I added KeyError to the inheritance list for ConfigMissingException so that you can use it more like a dictionary, like:

```python
c = ConfigTree()
..
try:
    v = c['my.key']
except KeyError:
    do_something()
```

The only thing I'm not entirely sure of is line 225-227.  It works, although I wasn't sure if you guys had a more preferred way to split/join key names

My commit msg:

> Added pop() method to ConfigTree that works like dict.pop().  Added test
cases as well
>
> Also, appended KeyError to ConfigMissingException so that exceptions can
be caught upstream via normal dict() syntax