### PR TITLE
ConfigTree.pop() should delete key when value == default_value

### DIFF
--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -220,6 +220,8 @@ class ConfigTree(OrderedDict):
         """
         value = self.get(key, default)
         if value == default:
+            if key in self:
+                del self[key]
             return default
 
         lst = ConfigTree.parse_key(key)

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -238,6 +238,11 @@ class TestConfigParser(object):
         assert config_tree == ConfigTree()
 
         config_tree = ConfigTree()
+        config_tree.put('key', 'value')
+        assert config_tree.pop('key', 'value') == 'value'
+        assert 'key' not in config_tree
+
+        config_tree = ConfigTree()
         config_tree.put('a.b.c.one', 1)
         config_tree.put('a.b.c.two', 2)
         config_tree.put('"f.k".g.three', 3)


### PR DESCRIPTION
`pop(key, default)` should remove the key even when its value equals the default

https://docs.python.org/3/library/stdtypes.html#dict.pop

I added a test that would have caught this.

(all of the `test_tool.py` tests fail for me even before I made any changes, so I don't know what I'm doing wrong there, but the new `test_config_tree.py` test passes)