### PR TITLE
Handle NoneValue for converting methods.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - 3.6
 before_install: pip install --upgrade setuptools
 install: pip install tox tox-travis coveralls
-before_script: tox -e flake8
+before_script: if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then tox -e flake8; fi
 script: tox -r
 after_success: coveralls
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - TOX_ENV=py27
   - TOX_ENV=py33
   - TOX_ENV=py34
+  - TOX_ENV=py36  
 install: pip install tox coveralls
 before_script: tox -e flake8
 script: tox -e ${TOX_ENV}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
-python: 2.7
-env:
-  - TOX_ENV=py26
-  - TOX_ENV=py27
-  - TOX_ENV=py33
-  - TOX_ENV=py34
-  - TOX_ENV=py36  
-install: pip install tox coveralls
+python:
+  - 2.6
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.6
+before_install: pip install --upgrade setuptools
+install: pip install tox tox-travis coveralls
 before_script: tox -e flake8
-script: tox -e ${TOX_ENV}
+script: tox -r
 after_success: coveralls
 sudo: false

--- a/pyhocon/tool.py
+++ b/pyhocon/tool.py
@@ -3,6 +3,8 @@ import logging
 import sys
 from pyhocon import ConfigFactory
 from pyhocon.config_tree import ConfigTree
+from pyhocon.config_tree import NoneValue
+
 
 try:
     basestring
@@ -52,7 +54,7 @@ class HOCONConverter(object):
                 lines += '\n{indent}]'.format(indent=''.rjust(level * indent, ' '))
         elif isinstance(config, basestring):
             lines = '"{value}"'.format(value=config.replace('\n', '\\n').replace('"', '\\"'))
-        elif config is None:
+        elif config is None or isinstance(config, NoneValue):
             lines = 'null'
         elif config is True:
             lines = 'true'
@@ -103,7 +105,7 @@ class HOCONConverter(object):
                 lines = '"""{value}"""'.format(value=config)  # multilines
             else:
                 lines = '"{value}"'.format(value=config.replace('\n', '\\n').replace('"', '\\"'))
-        elif config is None:
+        elif config is None or isinstance(config, NoneValue):
             lines = 'null'
         elif config is True:
             lines = 'true'
@@ -150,6 +152,8 @@ class HOCONConverter(object):
                 lines = config
             else:
                 lines = '|\n' + '\n'.join([line.rjust(level * indent, ' ') for line in lines])
+        elif config is None or isinstance(config, NoneValue):
+            lines = 'null'
         elif config is True:
             lines = 'true'
         elif config is False:
@@ -185,6 +189,8 @@ class HOCONConverter(object):
             lines.append('.'.join(stripped_key_stack) + ' = true')
         elif config is False:
             lines.append('.'.join(stripped_key_stack) + ' = false')
+        elif config is None or isinstance(config, NoneValue):
+            pass
         else:
             lines.append('.'.join(stripped_key_stack) + ' = ' + str(config))
         return '\n'.join([line for line in lines if len(line) > 0])

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -81,7 +81,7 @@ class TestHOCONConverter(object):
             f1: true
             f2: false
             g: []
-            h: None
+            h: null
             i:
             a.b: 2
         """

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py26, py27, py33, py34
+envlist = flake8, py26, py27, py33, py34, py36
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
This commit fixes handling NoneValue error with Python 3.6.

Original error is here: https://gist.github.com/chezou/7ffa23821188c02c55f148812df171bf

Fix #122 