### PR TITLE
Issue 141

### DIFF
--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -85,7 +85,7 @@ class ConfigTree(OrderedDict):
                     l.tokens.append(value)
                     l.recompute()
                 elif isinstance(l, ConfigTree) and isinstance(value, ConfigValues):
-                    value.tokens.append(l)
+                    value.tokens.insert(0,l)
                     value.recompute()
                     self._push_history(key_elt, value)
                     self[key_elt] = value

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -817,7 +817,7 @@ class TestConfigParser(object):
             x = ${x.y}
             """
         )
-        assert config.get("x.y") == {'y': 1}
+        assert config.get("x.y") == 1
         assert set(config.get("x").keys()) == set(['y'])
 
     def test_self_ref_substitution_dict_recurse(self):


### PR DESCRIPTION
Fix the correct answer for  test_self_ref_substitution_dict_path_hide by comparing with Java.

To get the test to pass again we need to modify the order of tokens: the existing tokens should be prepended instead of appended.

Addresses #141 