### PR TITLE
Issue 95

### DIFF
--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -12,6 +12,7 @@ except NameError:  # pragma: no cover
     unicode = str
 
 import re
+import copy
 from pyhocon.exceptions import ConfigException, ConfigWrongTypeException, ConfigMissingException
 
 
@@ -346,10 +347,10 @@ class ConfigTree(OrderedDict):
         :return: new config with fallback on config
         """
         if isinstance(config, ConfigTree):
-            result = ConfigTree.merge_configs(config, self)
+            result = ConfigTree.merge_configs(copy.deepcopy(config), copy.deepcopy(self))
         else:
             from . import ConfigFactory
-            result = ConfigTree.merge_configs(ConfigFactory.parse_file(config, resolve=False), self)
+            result = ConfigTree.merge_configs(ConfigFactory.parse_file(config, resolve=False), copy.deepcopy(self))
 
         from . import ConfigParser
         ConfigParser.resolve_substitutions(result)

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1671,8 +1671,13 @@ class TestConfigParser(object):
             """,
             resolve=False
         )
-        config2 = config2.with_fallback(config1)
-        assert config2.get("string") == 'abcdef'
+        result = config2.with_fallback(config1)
+        assert result.get("string") == 'abcdef'
+
+        ## test no mutation on config1
+        assert not result is config1
+        ## test no mutation on config2
+        assert not "abc" in str(config2)
 
     def test_object_field_substitution(self):
         config = ConfigFactory.parse_string(

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1674,10 +1674,10 @@ class TestConfigParser(object):
         result = config2.with_fallback(config1)
         assert result.get("string") == 'abcdef'
 
-        ## test no mutation on config1
-        assert not result is config1
-        ## test no mutation on config2
-        assert not "abc" in str(config2)
+        # test no mutation on config1
+        assert result is not config1
+        # test no mutation on config2
+        assert "abc" not in str(config2)
 
     def test_object_field_substitution(self):
         config = ConfigFactory.parse_string(


### PR DESCRIPTION
`config2.with_fallback(config1)` has the unexpected side-effect of returning `config1` and mutating it. The substitutions in `config` may also get mutated during the merge.

Fix this by doing  a deepcopy of config1, config2

The tests
* ensure that the return value is a new object different from config1
* check that the ConfigValue in config2 has not been mutated

Addresses #95, #105 