### PR TITLE
[SUPERSEDED] Issue 110: self merge with list of .overriden_value if they are also ConfigTree objects 

### DIFF
--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -423,7 +423,17 @@ class ConfigValues(object):
         return len(self.get_substitutions()) > 0
 
     def get_substitutions(self):
-        return [token for token in self.tokens if isinstance(token, ConfigSubstitution)]
+        lst = []
+        node = self
+        while node:
+            lst = [token for token in node.tokens if isinstance(token, ConfigSubstitution)] + lst
+            if hasattr(node, 'overriden_value'):
+                node = node.overriden_value
+                if not isinstance(node, ConfigValues):
+                    break
+            else:
+                break
+        return lst
 
     def transform(self):
         def determine_type(token):
@@ -459,7 +469,28 @@ class ConfigValues(object):
                         col=col(self._loc, self._instring)))
 
         if first_tok_type is ConfigTree:
+            child = []
+            if hasattr(self, 'overriden_value'):
+                node = self.overriden_value
+                while node:
+                    if isinstance(node, ConfigValues):
+                        value = node.transform()
+                        if isinstance(value, ConfigTree):
+                            child.append(value)
+                        else:
+                            break
+                    elif isinstance(node, ConfigTree):
+                        child.append(node)
+                    else:
+                        break
+                    if hasattr(node, 'overriden_value'):
+                        node = node.overriden_value
+                    else:
+                        break
+
             result = ConfigTree()
+            for conf in reversed(child):
+                ConfigTree.merge_configs(result, conf, copy_trees=True)
             for token in tokens:
                 ConfigTree.merge_configs(result, token, copy_trees=True)
             return result

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1980,3 +1980,15 @@ www.example-ö.com {
         assert {
             'a': {'d': 6}
         } == config_tree
+
+    def test_merge_overriden(self):
+        # Adress issue #110
+        # ConfigValues must merge with its .overriden_value
+        # if both are ConfigTree
+        config_tree = ConfigFactory.parse_string("""
+        foo: ${bar}
+        foo: ${baz}
+        bar:  {r: 1, s: 2}
+        baz:  {s: 3, t: 4}
+        """)
+        assert 'r' in config_tree['foo'] and 't' in config_tree['foo'] and config_tree['foo']['s'] == 3


### PR DESCRIPTION
[Update] this is required for proper handling of issue #145 as well so it has already been merged in PR #146 . This here for reference only.

- When a ConfigValues resolves to a ConfigTree we need to check the linked list of .overriden_value, and merge if we encounter adjacent ConfigTree. Stop when we reach a non-ConfigTree
- To resolve the linked list we add all substitutions from .overriden_value as well to .get_substitutions() (in bottom-most order first)
- expect that  .resolve_substitutions() will resolve the linked list members as well
- merge from bottom-most ConfigTree upwards

Addresses #110 