### PR TITLE
Issue 145: backtrack to handle self-references(includes #110)

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -442,6 +442,10 @@ class ConfigParser(object):
                     if not is_optional_resolved and substitution.optional:
                         resolved_value = None
 
+                    if isinstance(resolved_value, ConfigValues) and substitution.parent is resolved_value and hasattr(resolved_value, "overriden_value") and                        resolved_value.overriden_value:
+                        ## self resolution, backtrack
+                        resolved_value =  resolved_value.overriden_value
+
                     unresolved, new_substitutions, result = ConfigParser._do_substitute(substitution, resolved_value, is_optional_resolved)
                     any_unresolved = unresolved or any_unresolved
                     substitutions.extend(new_substitutions)

--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -452,9 +452,13 @@ class ConfigParser(object):
                                 link = getattr(link, 'overriden_value')
                             cache[resolved_value] = parents
 
-                    if isinstance(resolved_value, ConfigValues) and substitution.parent in parents and hasattr(substitution.parent, "overriden_value") and substitution.parent.overriden_value:
-                        ## self resolution, backtrack
-                        resolved_value =  substitution.parent.overriden_value
+                    if (isinstance(resolved_value, ConfigValues) and
+                        substitution.parent in parents and
+                        hasattr(substitution.parent, "overriden_value") and
+                        substitution.parent.overriden_value):
+
+                        # self resolution, backtrack
+                        resolved_value = substitution.parent.overriden_value
 
                     unresolved, new_substitutions, result = ConfigParser._do_substitute(substitution, resolved_value, is_optional_resolved)
                     any_unresolved = unresolved or any_unresolved

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -86,11 +86,17 @@ class ConfigTree(OrderedDict):
                     l.recompute()
                 elif isinstance(l, ConfigTree) and isinstance(value, ConfigValues):
                     value.tokens.append(l)
+                    value.overriden_value = l
                     value.recompute()
+                    value.parent = self
+                    value.key = key_elt
                     self._push_history(key_elt, value)
                     self[key_elt] = value
                 elif isinstance(l, list) and isinstance(value, ConfigValues):
                     self._push_history(key_elt, value)
+                    value.overriden_value = l
+                    value.parent = self
+                    value.key = key_elt
                     self[key_elt] = value
                 elif isinstance(l, list):
                     self[key_elt] = l + value
@@ -120,7 +126,7 @@ class ConfigTree(OrderedDict):
             if not isinstance(next_config_tree, ConfigTree):
                 # create a new dictionary or overwrite a previous value
                 next_config_tree = ConfigTree()
-                self._push_history(key_elt, value)
+                self._push_history(key_elt, next_config_tree)
                 self[key_elt] = next_config_tree
             next_config_tree._put(key_path[1:], value, append)
 

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -937,6 +937,7 @@ class TestConfigParser(object):
             """
                 a.b = 3
                 a.b = ${a.b}
+                a.b = ${a.b}
                 a.c = [1,2]
                 a.c = ${a.c}
                 a.d = {foo: bar}

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -937,9 +937,14 @@ class TestConfigParser(object):
             """
                 a.b = 3
                 a.b = ${a.b}
+                a.c = [1,2]
+                a.c = ${a.c}
+                a.d = {foo: bar}
+                a.d = ${a.d}
+
             """
         )
-        assert config.get("a") == {'b': 3}
+        assert config.get("a") == {'b': 3, 'c': [1,2], 'd': {'foo': 'bar'}}
 
     def test_concat_multi_line_string(self):
         config = ConfigFactory.parse_string(

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -932,6 +932,15 @@ class TestConfigParser(object):
         )
         assert config.get("x") == {'a': 1, 'b': 2, 'c': 3, 'z': 0, 'y': -1, 'd': 4}
 
+    def test_self_ref_child(self):
+        config = ConfigFactory.parse_string(
+            """
+                a.b = 3
+                a.b = ${a.b}
+            """
+        )
+        assert config.get("a") == {'b': 3}
+
     def test_concat_multi_line_string(self):
         config = ConfigFactory.parse_string(
             """

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -945,7 +945,7 @@ class TestConfigParser(object):
 
             """
         )
-        assert config.get("a") == {'b': 3, 'c': [1,2], 'd': {'foo': 'bar'}}
+        assert config.get("a") == {'b': 3, 'c': [1, 2], 'd': {'foo': 'bar'}}
 
     def test_concat_multi_line_string(self):
         config = ConfigFactory.parse_string(


### PR DESCRIPTION
Update: it is necessary to handle backtracking the entire chain of overriden_value, e.g.,
```
a.b = 1
a.b = ${a.b}
a.b = ${a.b}
```
The initial fix did not handle backtracking beyond one level. In order to handle this case, it seems easier to merge in PR #144 that exposes the ConfigValues in the overriden_value list. This supersedes PR #144.


```
a.b = 3
a.b = ${a.b}
## need to handle non-scalar objects as well
## multiple layers of backtracking
a.c = [1]
a.c = ${a.c}
a.c = ${a.c}
a.c = ${a.c}
a.d = {foo:bar}
a.d = ${a.d}
a.d = ${a.d}
a.d = ${a.d}
a.d = ${a.d}
```

In `ConfigParser.resolve_substitutions()`, we don't backtrack if the `substitution.parent is resolved.value` is `True`, i.e, the resolved value of the substitution is the originating ConfigValues. HOCON spec says to try to backtrack.
