### PR TITLE
Issue 125: complex substitution

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -456,6 +456,7 @@ class ConfigParser(object):
                         line=lineno(substitution.loc, substitution.instring),
                         col=col(substitution.loc, substitution.instring)) for substitution in substitutions)))
 
+        ConfigParser._final_fixup(config)
         return config
 
 

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1878,6 +1878,27 @@ test2 = test
             'd': 'foo          5        43'
         }
 
+    def test_complex_substitutions(self):
+        config = ConfigFactory.parse_string(
+            """
+            a: 1
+            b: ${c} {
+              pa: [${a}]
+              pb: ${b.pa}
+            }
+            c: { }
+            d: { pc: ${b.pa} }
+            e: ${b}
+            """, resolve=True)
+
+        assert config == {
+            'a': 1,
+            'b': {'pa': [1], 'pb': [1]},
+            'c': {},
+            'd': {'pc': [1]},
+            'e': {'pa': [1], 'pb': [1]}
+        }
+
     def test_assign_next_line(self):
         config = ConfigFactory.parse_string(
             """


### PR DESCRIPTION
Currently we end up with a ConfigTree w/o substitutions but one untransformed ConfigValues.

Add an additional fixup step and test

Addresses issue #125 