### PR TITLE
ADD: support attribute way to access key

### DIFF
--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -336,6 +336,13 @@ class ConfigTree(OrderedDict):
             raise KeyError(item)
         return val
 
+    def __getattr__(self, item):
+        class NotExsitedKey(object): pass
+        val = self.get(item, NotExsitedKey)
+        if val is NotExsitedKey:
+            return super(ConfigTree, self).__getattr__(item)
+        return val
+
     def __contains__(self, item):
         return self._get(self.parse_key(item), default=NoneValue) is not NoneValue
 


### PR DESCRIPTION
Support using attributes to access key
```python
conf = ConfigFactory.parse_file('databases.conf')
print conf.databases.mysql.password
```