### PR TITLE
Update Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.6
 before_install: pip install --upgrade setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - 2.7
   - 3.4
+  - 3.5
   - 3.6
 before_install: pip install --upgrade setuptools
 install: pip install tox tox-travis coveralls

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -80,22 +80,22 @@ class ConfigTree(OrderedDict):
             elif append:
                 # If we have t=1
                 # and we try to put t.a=5 then t is replaced by {a: 5}
-                l = self.get(key_elt, None)
-                if isinstance(l, ConfigValues):
-                    l.tokens.append(value)
-                    l.recompute()
-                elif isinstance(l, ConfigTree) and isinstance(value, ConfigValues):
-                    value.tokens.append(l)
+                l_value = self.get(key_elt, None)
+                if isinstance(l_value, ConfigValues):
+                    l_value.tokens.append(value)
+                    l_value.recompute()
+                elif isinstance(l_value, ConfigTree) and isinstance(value, ConfigValues):
+                    value.tokens.append(l_value)
                     value.recompute()
                     self._push_history(key_elt, value)
                     self[key_elt] = value
-                elif isinstance(l, list) and isinstance(value, ConfigValues):
+                elif isinstance(l_value, list) and isinstance(value, ConfigValues):
                     self._push_history(key_elt, value)
                     self[key_elt] = value
-                elif isinstance(l, list):
-                    self[key_elt] = l + value
-                    self._push_history(key_elt, l)
-                elif l is None:
+                elif isinstance(l_value, list):
+                    self[key_elt] = l_value + value
+                    self._push_history(key_elt, l_value)
+                elif l_value is None:
                     self._push_history(key_elt, value)
                     self[key_elt] = value
 
@@ -104,8 +104,8 @@ class ConfigTree(OrderedDict):
                         u"Cannot concatenate the list {key}: {value} to {prev_value} of {type}".format(
                             key='.'.join(key_path),
                             value=value,
-                            prev_value=l,
-                            type=l.__class__.__name__)
+                            prev_value=l_value,
+                            type=l_value.__class__.__name__)
                     )
             else:
                 # if there was an override keep overide value
@@ -381,9 +381,9 @@ class ConfigTree(OrderedDict):
 
 class ConfigList(list):
     def __init__(self, iterable=[]):
-        l = list(iterable)
-        super(ConfigList, self).__init__(l)
-        for index, value in enumerate(l):
+        new_list = list(iterable)
+        super(ConfigList, self).__init__(new_list)
+        for index, value in enumerate(new_list):
             if isinstance(value, ConfigValues):
                 value.parent = self
                 value.key = index

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -1,10 +1,7 @@
+from collections import OrderedDict
 from pyparsing import lineno
 from pyparsing import col
 
-try:  # pragma: no cover
-    from collections import OrderedDict
-except ImportError:  # pragma: no cover
-    from ordereddict import OrderedDict
 try:
     basestring
 except NameError:  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     packages=[
         'pyhocon',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ],
     packages=[

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,6 @@ import sys
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
-required_packages = ['pyparsing>=2.0.3']
-if sys.version_info[:2] == (2, 6):
-    required_packages.append('argparse')
-    required_packages.append('ordereddict')
-
 
 class PyTestCommand(TestCommand):
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
@@ -44,7 +39,6 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
@@ -52,7 +46,7 @@ setup(
     packages=[
         'pyhocon',
     ],
-    install_requires=required_packages,
+    install_requires=['pyparsing>=2.0.3'],
     tests_require=['pytest', 'mock'],
     entry_points={
         'console_scripts': [

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -3,15 +3,11 @@
 import os
 import mock
 import tempfile
+from collections import OrderedDict
 from pyparsing import ParseSyntaxException, ParseException
 import pytest
 from pyhocon import ConfigFactory, ConfigSubstitutionException, ConfigTree, ConfigParser
 from pyhocon.exceptions import ConfigMissingException, ConfigWrongTypeException, ConfigException
-
-try:  # pragma: no cover
-    from collections import OrderedDict
-except ImportError:  # pragma: no cover
-    from ordereddict import OrderedDict
 
 
 class TestConfigParser(object):

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -1,12 +1,8 @@
 import pytest
+from collections import OrderedDict
 from pyhocon.config_tree import ConfigTree
 from pyhocon.exceptions import (
     ConfigMissingException, ConfigWrongTypeException, ConfigException)
-
-try:  # pragma: no cover
-    from collections import OrderedDict
-except ImportError:  # pragma: no cover
-    from ordereddict import OrderedDict
 
 
 class TestConfigTree(object):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py27, py34, py36
+envlist = flake8, py27, py34, py35, py36
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py27, py33, py34, py36
+envlist = flake8, py27, py34, py36
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
Python 2.6 was already dropped, so remove some redundant 2.6-related code.

Python 3.3 is now EOL and no longer receiving security updates. It's also little used.

Here's the pip installs for pyhocon from PyPI for last month:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  98.51% |        472,531 |
| 3.4            |   1.06% |          5,086 |
| 3.6            |   0.23% |          1,081 |
| 3.5            |   0.15% |            731 |
| 2.6            |   0.05% |            250 |

Source: `pypinfo --start-date -47 --end-date -20 --percent --pip --markdown pyhocon pyversion`

Also add Python 3.5 to testing and classifiers, and 3.6 to classifiers.

Finally, fix flake8 to fix the 2.7 build.