### PR TITLE
Unresolved optional substitutions work with config merging

### DIFF
--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -58,7 +58,8 @@ class ConfigTree(OrderedDict):
                 if isinstance(value, ConfigValues):
                     value.parent = a
                     value.key = key
-                    value.overriden_value = a.get(key, None)
+                    if key in a:
+                        value.overriden_value = a[key]
                 a[key] = value
                 if a.root:
                     a.history[key] = (a.history.get(key) or []) + b.history.get(key)

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1277,6 +1277,21 @@ class TestConfigParser(object):
         assert config['database.name'] == 'peopledb'
         assert config['database.pass'] == 'peoplepass'
 
+    def test_optional_with_merge(self):
+        unresolved = ConfigFactory.parse_string(
+            """
+            foo: 42
+            foo: ${?a}
+            """, resolve=False)
+        source = ConfigFactory.parse_string(
+            """
+            b: 14
+            """)
+        config = unresolved.with_fallback(source)
+        assert config['foo'] == 42
+        config = source.with_fallback(unresolved)
+        assert config['foo'] == 42
+
     def test_optional_substitution(self):
         config = ConfigFactory.parse_string(
             """


### PR DESCRIPTION
If the  key is in the top layer and base layer, save the base value as the overriden_value

Addresses #154