### PR TITLE
Fix non-root ConfigTree merge onto root ConfigTree

### DIFF
--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -59,9 +59,13 @@ class ConfigTree(OrderedDict):
                     value.parent = a
                     value.key = key
                     value.overriden_value = a.get(key, None)
+
                 a[key] = value
                 if a.root:
-                    a.history[key] = (a.history.get(key) or []) + b.history.get(key)
+                    if b.root:
+                        a.history[key] = a.history.get(key, []) + b.history.get(key, [value])
+                    else:
+                        a.history[key] = a.history.get(key, []) + [value]
 
         return a
 

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -59,7 +59,6 @@ class ConfigTree(OrderedDict):
                     value.parent = a
                     value.key = key
                     value.overriden_value = a.get(key, None)
-
                 a[key] = value
                 if a.root:
                     if b.root:

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1690,6 +1690,17 @@ class TestConfigParser(object):
         # test no mutation on config2
         assert "abc" not in str(config2)
 
+    def test_fallback_non_root(self):
+        root = ConfigFactory.parse_string(
+            """
+            a = 1
+            mid.b = 1
+            """
+        )
+
+        config = root.get_config("mid").with_fallback(root)
+        assert config['a'] == 1 and config['b'] == 1
+
     def test_object_field_substitution(self):
         config = ConfigFactory.parse_string(
             """


### PR DESCRIPTION
When merging a non-root ConfigTree onto a root ConfigTree create history of element if it does not exist.