### PR TITLE
Support scientific expression of number

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -290,6 +290,9 @@ class ConfigParser(object):
         comment_no_comma_eol = (comment | eol).suppress()
         number_expr = Regex('[+-]?(\d*\.\d+|\d+(\.\d+)?)([eE]\d+)?(?=$|[ \t]*([\$\}\],#\n\r]|//))',
                             re.DOTALL).setParseAction(convert_number)
+        sci_regex = Regex(r'[+-]?\d+([eE][+-]?\d+|\.\d*([eE][+-]?\d+)?)', re.DOTALL)
+        sci_real = sci_regex.setParseAction(convert_number)
+        number_expr = number_expr | sci_real
 
         # multi line string using """
         # Using fix described in http://pyparsing.wikispaces.com/share/view/3778969

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -2167,3 +2167,18 @@ www.example-ö.com {
         config = ConfigFactory.parse_string(source)
         assert config == expected
         assert config == json.loads(source)
+
+    def test_sci_real(self):
+        """
+        Test scientific expression of number
+        """
+
+        config = """
+        a = 1e-3
+        b = 1e3
+        c = 1
+        """
+        conf = ConfigFactory.parse_string(config)
+        assert conf.a == float('1e-3')
+        assert conf.b == float('1e3')
+        assert conf.c == int('1')


### PR DESCRIPTION
pyhocon does not support numbers in scientific format. related to issue #176 