### PR TITLE
Handle ConfigValues and ConfigSubstitution in HOCONConverter.to_hocon

### DIFF
--- a/pyhocon/converter.py
+++ b/pyhocon/converter.py
@@ -1,10 +1,12 @@
 import sys
 
 from pyhocon import ConfigFactory
+from pyhocon.config_tree import ConfigQuotedString
 from pyhocon.config_tree import ConfigSubstitution
 from pyhocon.config_tree import ConfigTree
 from pyhocon.config_tree import ConfigValues
 from pyhocon.config_tree import NoneValue
+
 
 try:
     basestring
@@ -118,6 +120,11 @@ class HOCONConverter(object):
             if config.optional:
                 lines += '?'
             lines += config.variable + '}' + config.ws
+        elif isinstance(config, ConfigQuotedString):
+            if '\n' in config.value:
+                lines = '"""{value}"""'.format(value=config.value)  # multilines
+            else:
+                lines = '"{value}"'.format(value=config.value.replace('\n', '\\n').replace('"', '\\"'))
         elif config is None or isinstance(config, NoneValue):
             lines = 'null'
         elif config is True:

--- a/pyhocon/converter.py
+++ b/pyhocon/converter.py
@@ -1,7 +1,9 @@
 import sys
 
 from pyhocon import ConfigFactory
+from pyhocon.config_tree import ConfigSubstitution
 from pyhocon.config_tree import ConfigTree
+from pyhocon.config_tree import ConfigValues
 from pyhocon.config_tree import NoneValue
 
 try:
@@ -109,6 +111,13 @@ class HOCONConverter(object):
                 lines = '"""{value}"""'.format(value=config)  # multilines
             else:
                 lines = '"{value}"'.format(value=config.replace('\n', '\\n').replace('"', '\\"'))
+        elif isinstance(config, ConfigValues):
+            lines = ''.join(cls.to_hocon(o, compact, indent, level) for o in config.tokens)
+        elif isinstance(config, ConfigSubstitution):
+            lines = '${'
+            if config.optional:
+                lines += '?'
+            lines += config.variable + '}' + config.ws
         elif config is None or isinstance(config, NoneValue):
             lines = 'null'
         elif config is True:

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -174,7 +174,7 @@ def test_substitutions_conversions():
     data-center-east = ${data-center-generic} { name = "east" }
 
     # you can use substitution with unquoted strings. If it it not found in the document, it defaults to environment variables
-    home_dir = ${HOME} # you can substitute with environment variables
+    home_dir = ${HOME}"/work" # you can substitute with environment variables
 
     // list merge
     default-jvm-opts = ["-XX:+UseParNewGC"]

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -164,3 +164,24 @@ class TestHOCONConverter(object):
     def test_invalid_format(self):
         with pytest.raises(Exception):
             self._test_convert_from_file(TestHOCONConverter.CONFIG_STRING, TestHOCONConverter.EXPECTED_PROPERTIES, 'invalid')
+
+
+def test_substitutions_conversions():
+    config_string = """
+{
+    // dict merge
+    data-center-generic = { cluster-size = 6 }
+    data-center-east = ${data-center-generic} { name = "east" }
+
+    # you can use substitution with unquoted strings. If it it not found in the document, it defaults to environment variables
+    home_dir = ${HOME} # you can substitute with environment variables
+
+    // list merge
+    default-jvm-opts = ["-XX:+UseParNewGC"]
+    large-jvm-opts = ${default-jvm-opts} [-Xm16g]
+}
+    """
+    converted1 = HOCONConverter.to_hocon(ConfigFactory.parse_string(config_string, resolve=False))
+    converted2 = HOCONConverter.to_hocon(ConfigFactory.parse_string(converted1, resolve=False))
+    assert [line.strip() for line in converted1.split('\n') if line.strip()] \
+           == [line.strip() for line in converted2.split('\n') if line.strip()]


### PR DESCRIPTION
As also mentioned by Ivan@renardeinside on gitter, I encountered this bug and made a fix for it (plus a test):

Hi everyone.
I found something strange in HOCONConverter.convert(config,"hocon").
Probably i haven't enough understanding, but if you want to convert come config with unresolved substitution, you got strange result.
Suppose, you have file like this

`parameter = ${substition.v1}`

Then you parse this file and you won't resolve substitution:

`config = ConfigFactory.parse_file("example.conf",resolve=False)`

Then if you convert this config you got this result code:

`print(HOCONConverter.convert(config,"hocon"))`

output:

`parameter = [ConfigValues: [ConfigSubstitution: substition.v1]]`

But probably the result should be:

`parameter = ${substition.v1}`