### PR TITLE
Do not unquote keys containing special characters

### DIFF
--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -174,14 +174,20 @@ class ConfigTree(OrderedDict):
         """
         Split a key into path elements:
         - a.b.c => a, b, c
-        - a."b.c" => a, QuotedKey("b.c")
+        - a."b.c" => a, QuotedKey("b.c") if . is any of the special characters: $}[]:=+#`^?!@*&.
         - "a" => a
         - a.b."c" => a, b, c (special case)
         :param str:
         :return:
         """
-        tokens = re.findall(r'"[^"]+"|[^\.]+', string)
-        return [token if '.' in token else token.strip('"') for token in tokens]
+        special_characters = '$}[]:=+#`^?!@*&.'
+        tokens = re.findall(r'"[^"]+"|[^'+re.escape(special_characters)+r']+', string)
+
+        def contains_special_character(token):
+            if any((c in special_characters) for c in token):
+                return True
+            return False
+        return [token if contains_special_character(token) else token.strip('"') for token in tokens]
 
     def put(self, key, value, append=False):
         """Put a value in the tree (dot separated)

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -181,7 +181,7 @@ class ConfigTree(OrderedDict):
         :return:
         """
         special_characters = '$}[]:=+#`^?!@*&.'
-        tokens = re.findall(r'"[^"]+"|[^'+re.escape(special_characters)+r']+', string)
+        tokens = re.findall(r'"[^"]+"|[^{special_characters}]+'.format(special_characters=re.escape(special_characters)), string)
 
         def contains_special_character(token):
             if any((c in special_characters) for c in token):

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -315,8 +315,8 @@ class TestConfigTree(object):
         special_characters = '$}[]:=+#`^?!@*&.'
         for char in special_characters:
             config_tree = ConfigTree()
-            escaped_key = f"\"test{char}key\""
-            key = f"a.b.{escaped_key}"
+            escaped_key = "\"test{char}key\"".format(char=char)
+            key = "a.b.{escaped_key}".format(escaped_key=escaped_key)
             config_tree.put(key, "value")
             hocon_tree = HOCONConverter.to_hocon(config_tree)
             assert escaped_key in hocon_tree

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -3,6 +3,8 @@ from collections import OrderedDict
 from pyhocon.config_tree import ConfigTree, NoneValue
 from pyhocon.exceptions import (
     ConfigMissingException, ConfigWrongTypeException, ConfigException)
+from pyhocon.config_parser import ConfigFactory
+from pyhocon.tool import HOCONConverter
 
 
 class TestConfigTree(object):
@@ -308,3 +310,15 @@ class TestConfigTree(object):
         ]:
             with pytest.raises(ConfigMissingException):
                 assert getter('missing_key')
+
+    def test_config_tree_special_characters(self):
+        special_characters = '$}[]:=+#`^?!@*&.'
+        for char in special_characters:
+            config_tree = ConfigTree()
+            escaped_key = f"\"test{char}key\""
+            key = f"a.b.{escaped_key}"
+            config_tree.put(key, "value")
+            hocon_tree = HOCONConverter.to_hocon(config_tree)
+            assert escaped_key in hocon_tree
+            parsed_tree = ConfigFactory.parse_string(hocon_tree)
+            assert parsed_tree.get(key) == "value"


### PR DESCRIPTION
When using a key that contains special characters, the pyhocon generated is invalid. For example:
```
config_tree = ConfigTree()
escaped_key = f"\"test&key\""
key = f"{escaped_key}"
config_tree.put(key, "value")
hocon_tree = HOCONConverter.to_hocon(config_tree)
```
Which generates a pyhocon:
```
test&key: value
```

This PR attempts to alleviate the issue with allowing double quoted strings as keys when they contain a special character. The full list of special characters can be seen here: https://github.com/lightbend/config/blob/master/HOCON.md#unquoted-strings

I could not manage to make a concise fix while also supporting special characters: `{,"`, as those would require some sort of escaping.

I am not entirely sure whether keys with these characters are even supported within the HOCON definition, please let me know.