### PR TITLE
Use std json library to fix json string escaping.

### DIFF
--- a/pyhocon/converter.py
+++ b/pyhocon/converter.py
@@ -1,3 +1,4 @@
+import json
 import sys
 
 from pyhocon import ConfigFactory
@@ -47,7 +48,7 @@ class HOCONConverter(object):
                 lines += ',\n'.join(bet_lines)
                 lines += '\n{indent}]'.format(indent=''.rjust(level * indent, ' '))
         elif isinstance(config, basestring):
-            lines = '"{value}"'.format(value=config.replace('\n', '\\n').replace('"', '\\"'))
+            lines = '{value}'.format(value=json.dumps(config))
         elif config is None or isinstance(config, NoneValue):
             lines = 'null'
         elif config is True:

--- a/pyhocon/converter.py
+++ b/pyhocon/converter.py
@@ -48,7 +48,7 @@ class HOCONConverter(object):
                 lines += ',\n'.join(bet_lines)
                 lines += '\n{indent}]'.format(indent=''.rjust(level * indent, ' '))
         elif isinstance(config, basestring):
-            lines = '{value}'.format(value=json.dumps(config))
+            lines = json.dumps(config)
         elif config is None or isinstance(config, NoneValue):
             lines = 'null'
         elif config is True:


### PR DESCRIPTION
This is a fix for https://github.com/chimpler/pyhocon/issues/174

It leverages the std json lib to handle properly escaping strings when converting to json.

`python setup.py test` passes