### PR TITLE
Fix self references when environment variables exist

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -89,7 +89,7 @@ class ConfigFactory(object):
         :param unresolved_value: assigned value value to unresolved substitution.
         If overriden with a default value, it will replace all unresolved value to the default value.
         If it is set to to pyhocon.STR_SUBSTITUTION then it will replace the value by its substitution expression (e.g., ${x})
-        :type unresolved_value: boolean
+        :type unresolved_value: class
         :return: Config object
         :type return: Config
         """
@@ -484,13 +484,18 @@ class ConfigParser(object):
                                 _, _, current_item = cls._do_substitute(substitution, value)
                     previous_item = current_item
 
-                if len(history) == 1:  # special case, when self optional referencing without existing
+                if len(history) == 1:
                     for substitution in cls._find_substitutions(previous_item):
                         prop_path = ConfigTree.parse_key(substitution.variable)
                         if len(prop_path) > 1 and config.get(substitution.variable, None) is not None:
                             continue  # If value is present in latest version, don't do anything
-                        if prop_path[0] == key and substitution.optional:
-                            cls._do_substitute(substitution, None)
+                        if prop_path[0] == key:
+                            value = os.environ.get(key)
+                            if value is not None:
+                                cls._do_substitute(substitution, value)
+                                continue
+                            if substitution.optional:  # special case, when self optional referencing without existing
+                                cls._do_substitute(substitution, None)
 
     # traverse config to find all the substitutions
     @classmethod

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -2106,6 +2106,26 @@ test2 = test
             'string_from_env': 'value_from_environment'
         }
 
+    @mock.patch.dict(os.environ, STRING_VAR='value_from_environment')
+    def test_string_from_environment_self_ref(self):
+        config = ConfigFactory.parse_string(
+            """
+            STRING_VAR = ${STRING_VAR}
+            """)
+        assert config == {
+            'STRING_VAR': 'value_from_environment'
+        }
+
+    @mock.patch.dict(os.environ, STRING_VAR='value_from_environment')
+    def test_string_from_environment_self_ref_optional(self):
+        config = ConfigFactory.parse_string(
+            """
+            STRING_VAR = ${?STRING_VAR}
+            """)
+        assert config == {
+            'STRING_VAR': 'value_from_environment'
+        }
+
     @mock.patch.dict(os.environ, TRUE_OR_FALSE='false')
     def test_bool_from_environment(self):
         config = ConfigFactory.parse_string(


### PR DESCRIPTION
This PR fixes issue https://github.com/chimpler/pyhocon/issues/213 . 

Essentially, I was blocked by not being able to import an environment variable verbatim into a pyhocon config. I.e. if I have an environment variable `MYVAR=123`, the following `test.conf` failed:
```
MYVAR=${MYVAR}
```
or 
```
MYVAR=${?MYVAR}
```
The only workaround was to assign it to another variable and then handle it as a special case in code. Or to introduce another extra env var into production systems. It is difficult to do so, since they are configuration settings, and people have to be educated on them.

This PR fixes the issue by looking for environment variables when fixing up self references.