### PR TITLE
Remove inactive Gitter channel from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ pyhocon
 [![License](https://img.shields.io/pypi/l/Pyhocon.svg)](https://pypi.python.org/pypi/pyhocon/)
 [![Coverage Status](https://coveralls.io/repos/chimpler/pyhocon/badge.svg)](https://coveralls.io/r/chimpler/pyhocon)
 [![Requirements Status](https://requires.io/github/chimpler/pyhocon/requirements.svg?branch=master)](https://requires.io/github/chimpler/pyhocon/requirements/?branch=master)
-[![Join the chat at https://gitter.im/chimpler/pyhocon](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/chimpler/pyhocon?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 HOCON parser for Python
 


### PR DESCRIPTION
The [gitter channel](https://gitter.im/chimpler/pyhocon?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) history has five people, each asking one question, receiving a total of zero responses.

Since it's clearly not an active discussion forum, let's remove it from the README so people won't waste their time posting there.