### PR TITLE
Add support for package include

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ We support the include semantics using one of the followings:
     include url("http://abc.com/test.conf")
     include url("https://abc.com/test.conf")
     include url("file://abc.com/test.conf")
+    include package("package:assets/test.conf")
 
 When one uses a relative path (e.g., test.conf), we use the same directory as the file that includes the new file as a base directory. If
 the standard input is used, we use the current directory as a base directory.
@@ -294,43 +295,43 @@ assert config == d
 
 ## TODO
 
-Items                                  | Status
--------------------------------------- | :-----:
-Comments                               | :white_check_mark:
-Omit root braces                       | :white_check_mark:
-Key-value separator                    | :white_check_mark:
-Commas                                 | :white_check_mark:
-Whitespace                             | :white_check_mark:
-Duplicate keys and object merging      | :white_check_mark:
-Unquoted strings                       | :white_check_mark:
-Multi-line strings                     | :white_check_mark:
-String value concatenation             | :white_check_mark:
-Array concatenation                    | :white_check_mark:
-Object concatenation                   | :white_check_mark:
-Arrays without commas                  | :white_check_mark:
-Path expressions                       | :white_check_mark:
-Paths as keys                          | :white_check_mark:
-Substitutions                          | :white_check_mark:
-Self-referential substitutions         | :white_check_mark:
-The `+=` separator                     | :white_check_mark:
-Includes                               | :white_check_mark:
-Include semantics: merging             | :white_check_mark:
-Include semantics: substitution        | :white_check_mark:
-Include semantics: missing files       | :x:
-Include semantics: file formats and extensions     | :x:
-Include semantics: locating resources              | :x:
-Include semantics: preventing cycles               | :x:
-Conversion of numerically-index objects to arrays  | :white_check_mark:
+| Items                                             |       Status       |
+| ------------------------------------------------- | :----------------: |
+| Comments                                          | :white_check_mark: |
+| Omit root braces                                  | :white_check_mark: |
+| Key-value separator                               | :white_check_mark: |
+| Commas                                            | :white_check_mark: |
+| Whitespace                                        | :white_check_mark: |
+| Duplicate keys and object merging                 | :white_check_mark: |
+| Unquoted strings                                  | :white_check_mark: |
+| Multi-line strings                                | :white_check_mark: |
+| String value concatenation                        | :white_check_mark: |
+| Array concatenation                               | :white_check_mark: |
+| Object concatenation                              | :white_check_mark: |
+| Arrays without commas                             | :white_check_mark: |
+| Path expressions                                  | :white_check_mark: |
+| Paths as keys                                     | :white_check_mark: |
+| Substitutions                                     | :white_check_mark: |
+| Self-referential substitutions                    | :white_check_mark: |
+| The `+=` separator                                | :white_check_mark: |
+| Includes                                          | :white_check_mark: |
+| Include semantics: merging                        | :white_check_mark: |
+| Include semantics: substitution                   | :white_check_mark: |
+| Include semantics: missing files                  |        :x:         |
+| Include semantics: file formats and extensions    |        :x:         |
+| Include semantics: locating resources             |        :x:         |
+| Include semantics: preventing cycles              |        :x:         |
+| Conversion of numerically-index objects to arrays | :white_check_mark: |
 
-API Recommendations                                        | Status
----------------------------------------------------------- | :----:
-Conversion of numerically-index objects to arrays          | :x:
-Automatic type conversions                                 | :x:
-Units format                                               | :x:
-Duration format                                            | :x:
-Size in bytes format                                       | :x:
-Config object merging and file merging                     | :x:
-Java properties mapping                                    | :x:
+| API Recommendations                               | Status |
+| ------------------------------------------------- | :----: |
+| Conversion of numerically-index objects to arrays |  :x:   |
+| Automatic type conversions                        |  :x:   |
+| Units format                                      |  :x:   |
+| Duration format                                   |  :x:   |
+| Size in bytes format                              |  :x:   |
+| Config object merging and file merging            |  :x:   |
+| Java properties mapping                           |  :x:   |
 
 ### Contributors
 

--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -1,19 +1,25 @@
-import itertools
-import re
-import os
-import socket
-import contextlib
 import codecs
+import contextlib
+import copy
+import itertools
+import logging
+import os
+import re
+import socket
 from datetime import timedelta
 
-from pyparsing import Forward, Keyword, QuotedString, Word, Literal, Suppress, Regex, Optional, SkipTo, ZeroOrMore, \
-    Group, lineno, col, TokenConverter, replaceWith, alphanums, alphas8bit, ParseSyntaxException, StringEnd
-from pyparsing import ParserElement
-from pyhocon.config_tree import ConfigTree, ConfigSubstitution, ConfigList, ConfigValues, ConfigUnquotedString, \
-    ConfigInclude, NoneValue, ConfigQuotedString
-from pyhocon.exceptions import ConfigSubstitutionException, ConfigMissingException, ConfigException
-import logging
-import copy
+from pyparsing import (Forward, Group, Keyword, Literal, Optional,
+                       ParserElement, ParseSyntaxException, QuotedString,
+                       Regex, SkipTo, StringEnd, Suppress, TokenConverter,
+                       Word, ZeroOrMore, alphanums, alphas8bit, col, lineno,
+                       replaceWith)
+
+import asset
+from pyhocon.config_tree import (ConfigInclude, ConfigList, ConfigQuotedString,
+                                 ConfigSubstitution, ConfigTree,
+                                 ConfigUnquotedString, ConfigValues, NoneValue)
+from pyhocon.exceptions import (ConfigException, ConfigMissingException,
+                                ConfigSubstitutionException)
 
 use_urllib2 = False
 try:
@@ -317,6 +323,8 @@ class ConfigParser(object):
                 value = final_tokens[1].value if isinstance(token[1], ConfigQuotedString) else final_tokens[1]
                 if final_tokens[0] == 'url':
                     url = value
+                elif final_tokens[0] == 'package':
+                    file = asset.load(value).filename
                 else:
                     file = value
 
@@ -384,7 +392,7 @@ class ConfigParser(object):
 
             value_expr = period_expr | number_expr | true_expr | false_expr | null_expr | string_expr
 
-            include_content = (quoted_string | ((Keyword('url') | Keyword('file')) - Literal('(').suppress() - quoted_string - Literal(')').suppress()))
+            include_content = (quoted_string | ((Keyword('url') | Keyword('file') | Keyword('package')) - Literal('(').suppress() - quoted_string - Literal(')').suppress()))
             include_expr = (
                 Keyword("include", caseless=True).suppress() + (
                     include_content | (

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import sys
+
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
@@ -49,7 +50,7 @@ setup(
     packages=[
         'pyhocon',
     ],
-    install_requires=['pyparsing>=2.0.3'],
+    install_requires=['pyparsing>=2.0.3', 'asset'],
     extras_require={
         'Duration': ['python-dateutil>=2.8.0']
     },

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -2,21 +2,26 @@
 
 import json
 import os
+import tempfile
+from collections import OrderedDict
+from datetime import timedelta
+
+from pyparsing import ParseBaseException, ParseException, ParseSyntaxException
+
+import asset
+import mock
+import pytest
+from pyhocon import (ConfigFactory, ConfigParser, ConfigSubstitutionException,
+                     ConfigTree)
+from pyhocon.exceptions import (ConfigException, ConfigMissingException,
+                                ConfigWrongTypeException)
 
 try:
     from dateutil.relativedelta import relativedelta as period
 except Exception:
     from datetime import timedelta as period
 
-from datetime import timedelta
 
-import mock
-import tempfile
-from collections import OrderedDict
-from pyparsing import ParseSyntaxException, ParseException, ParseBaseException
-import pytest
-from pyhocon import ConfigFactory, ConfigSubstitutionException, ConfigTree, ConfigParser
-from pyhocon.exceptions import ConfigMissingException, ConfigWrongTypeException, ConfigException
 
 
 class TestConfigParser(object):
@@ -1228,6 +1233,37 @@ class TestConfigParser(object):
                 ]
                 """
             )
+
+    def test_include_asset_file(self, monkeypatch):
+
+        expected = {
+            'a': {
+                'garfield': {
+                    'say': 'meow'
+                },
+                't': 2
+            }
+        }
+
+        with tempfile.NamedTemporaryFile('w') as fdin:
+            fdin.write('{a: 1, b: 2}')
+            fdin.flush()
+
+            def load(*args, **kwargs):
+                print(*args, **kwargs)
+                class File:
+                    def __init__(self, filename):
+                        self.filename = filename
+                return File(fdin.name)
+
+            monkeypatch.setattr(asset, "load", load)
+
+            config = ConfigFactory.parse_string(
+                """
+                include package("dotted.name:asset/config_file")
+                """
+            )
+            assert config['a'] == 1
 
     def test_include_dict(self):
         expected_res = {


### PR DESCRIPTION
In our company, we want to deploy config files as part of Python packages, so we can versionize these. Therefor we would like to include assets from packages in hocon config files. This PR adds the ability to do so.