### PR TITLE
Fix required(file()) syntax

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -314,7 +314,7 @@ class ConfigParser(object):
                 else:
                     file = value
             elif len(final_tokens) == 2:  # include url("test") or file("test")
-                value = final_tokens[1].value if isinstance(token[1], ConfigQuotedString) else final_tokens[1]
+                value = final_tokens[1].value if isinstance(final_tokens[1], ConfigQuotedString) else final_tokens[1]
                 if final_tokens[0] == 'url':
                     url = value
                 else:

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1217,6 +1217,16 @@ class TestConfigParser(object):
         }
         assert expected == config
 
+        config2 = ConfigFactory.parse_string(
+            """
+            a {
+                include required(file("samples/cat.conf"))
+                t = 2
+            }
+            """
+        )
+        assert expected == config2
+
     def test_include_missing_required_file(self):
         with pytest.raises(IOError):
             ConfigFactory.parse_string(


### PR DESCRIPTION
This PR applies the suggested fix from https://github.com/chimpler/pyhocon/issues/187 and adds a test for it as well.

Seems to work on my machine.

@chimpler 