### PR TITLE
Fix parsing of durations/periods

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -371,10 +371,15 @@ class ConfigParser(object):
             comment_no_comma_eol = (comment | eol).suppress()
             number_expr = Regex(r'[+-]?(\d*\.\d+|\d+(\.\d+)?)([eE][+\-]?\d+)?(?=$|[ \t]*([\$\}\],#\n\r]|//))',
                                 re.DOTALL).setParseAction(convert_number)
-
-            period_types = itertools.chain.from_iterable(cls.get_supported_period_type_map().values())
-            period_expr = Regex(r'(?P<value>\d+)\s*(?P<unit>' + '|'.join(period_types) + ')$'
-                                ).setParseAction(convert_period)
+            # Must be sorted from longest to shortest otherwise 'weeks' will match 'w' and 'eeks'
+            # will be parsed as a general string.
+            period_types = sorted(
+                itertools.chain.from_iterable(cls.get_supported_period_type_map().values()),
+                key=lambda x: len(x), reverse=True)
+            period_expr = Regex(
+                r'(?P<value>\d+)\s*(?P<unit>' + '|'.join(period_types) + ')$',
+                flags=re.MULTILINE,
+            ).setParseAction(convert_period)
 
             # multi line string using """
             # Using fix described in http://pyparsing.wikispaces.com/share/view/3778969

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -670,7 +670,7 @@ class TestConfigParser(object):
     def test_substitution_list_with_append(self):
         config = ConfigFactory.parse_string(
             """
-            application.foo = 128m
+            application.foo = 128mm
             application.large-jvm-opts = ["-XX:+UseParNewGC"] [-Xm16g, ${application.foo}]
             application.large-jvm-opts2 = [-Xm16g, ${application.foo}] ["-XX:+UseParNewGC"]
             """)
@@ -678,19 +678,19 @@ class TestConfigParser(object):
         assert config["application.large-jvm-opts"] == [
             '-XX:+UseParNewGC',
             '-Xm16g',
-            '128m'
+            '128mm'
         ]
 
         assert config["application.large-jvm-opts2"] == [
             '-Xm16g',
-            '128m',
+            '128mm',
             '-XX:+UseParNewGC',
         ]
 
     def test_substitution_list_with_append_substitution(self):
         config = ConfigFactory.parse_string(
             """
-            application.foo = 128m
+            application.foo = 128mm
             application.default-jvm-opts = ["-XX:+UseParNewGC"]
             application.large-jvm-opts = ${application.default-jvm-opts} [-Xm16g, ${application.foo}]
             application.large-jvm-opts2 = [-Xm16g, ${application.foo}] ${application.default-jvm-opts}
@@ -699,12 +699,12 @@ class TestConfigParser(object):
         assert config["application.large-jvm-opts"] == [
             '-XX:+UseParNewGC',
             '-Xm16g',
-            '128m'
+            '128mm'
         ]
 
         assert config["application.large-jvm-opts2"] == [
             '-Xm16g',
-            '128m',
+            '128mm',
             '-XX:+UseParNewGC'
         ]
 

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -138,6 +138,16 @@ class TestConfigParser(object):
 
         assert config['a'] == data_set[1]
 
+    def test_parse_string_with_duration_with_long_unit_name(self):
+        config = ConfigFactory.parse_string(
+            """
+            a: foo
+            b: 10 weeks
+            c: bar
+            """
+        )
+        assert config['b'] == period(weeks=10)
+
     def test_parse_with_enclosing_square_bracket(self):
         config = ConfigFactory.parse_string("[1, 2, 3]")
         assert config == [1, 2, 3]


### PR DESCRIPTION
There were 2 problems:
* `$` was used without the `re.MULTILINE` flag thus forcing the end of the stream. 
 The duration was parsed only if it was on the last line.
* Regex engine prefers first match when a group of strings with OR operator is given.

  If the input string is `months` and the regex is `m|month|months` the
  math is `m` and the rest `onths` is left to the other parsers.
  
  It should be enough just to sort the strings by the length. `months` will match and should be
  correctly extracted from the token stream.

As I am running Python 3.8 some tests are failing. It should be, however, working just fine on 3.7.

There were 2 tests I had to update. Both of them contain a value of `128m` that was previously parsed as a string.
Now it will be parsed as duration. As a workaround, I modified it to `128mm`. Feel free to change it to whatever 
you want.

This fixes #215 .