### PR TITLE
Rewrite the logic to resolve package-relative paths so we can remove the "asset" library

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -713,7 +713,7 @@ class ConfigParser(object):
         return has_unresolved
 
     @classmethod
-    def resolve_package_path(cls, package_path: str) -> str:
+    def resolve_package_path(cls, package_path):
         """
         Resolve the path to a file inside a Python package. Expected format: "PACKAGE:PATH"
 
@@ -726,7 +726,7 @@ class ConfigParser(object):
         """
         if ':' not in package_path:
             raise ValueError("Expected format is 'PACKAGE:PATH'")
-        package_name, path_relative = package_path.split(':', maxsplit=1)
+        package_name, path_relative = package_path.split(':', 1)
         package_dir = imp.find_module(package_name)[1]
         path_abs = os.path.join(package_dir, path_relative)
         return path_abs

--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -30,7 +30,6 @@ if sys.version_info >= (3, 8):
 
     pyparsing.ParseResults.__getattr__ = fixed_get_attr
 
-import asset
 from pyhocon.config_tree import (ConfigInclude, ConfigList, ConfigQuotedString,
                                  ConfigSubstitution, ConfigTree,
                                  ConfigUnquotedString, ConfigValues, NoneValue)

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     packages=[
         'pyhocon',
     ],
-    install_requires=['pyparsing>=2.0.3', 'asset'],
+    install_requires=['pyparsing>=2.0.3'],
     extras_require={
         'Duration': ['python-dateutil>=2.8.0']
     },

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 import tempfile
 from collections import OrderedDict
 from datetime import timedelta
@@ -1279,8 +1280,8 @@ class TestConfigParser(object):
             ConfigParser.resolve_package_path("non_existent_module:foo.py")
 
     def test_include_package_file(self, monkeypatch):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # define paths
+        temp_dir = tempfile.mkdtemp()
+        try:
             module_dir = os.path.join(temp_dir, 'my_module')
             module_conf = os.path.join(module_dir, 'my.conf')
             # create the module folder and necessary files (__init__ and config)
@@ -1300,6 +1301,8 @@ class TestConfigParser(object):
             )
             # check that the contents of both config files are available
             assert dict(config.as_plain_ordered_dict()) == {'a': 1, 'b': 2, 'c': 3}
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
 
     def test_include_dict(self):
         expected_res = {

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -7,7 +7,6 @@ from collections import OrderedDict
 from datetime import timedelta
 
 from pyparsing import ParseBaseException, ParseException, ParseSyntaxException
-import asset
 import mock
 import pytest
 from pyhocon import (ConfigFactory, ConfigParser, ConfigSubstitutionException, ConfigTree)
@@ -1267,26 +1266,40 @@ class TestConfigParser(object):
                 """
             )
 
-    def test_include_asset_file(self, monkeypatch):
-        with tempfile.NamedTemporaryFile('w') as fdin:
-            fdin.write('{a: 1, b: 2}')
-            fdin.flush()
+    def test_resolve_package_path(self):
+        path = ConfigParser.resolve_package_path("pyhocon:config_parser.py")
+        assert os.path.exists(path)
 
-            def load(*args, **kwargs):
-                class File(object):
-                    def __init__(self, filename):
-                        self.filename = filename
+    def test_resolve_package_path_format(self):
+        with pytest.raises(ValueError):
+            ConfigParser.resolve_package_path("pyhocon/config_parser.py")
 
-                return File(fdin.name)
+    def test_resolve_package_path_missing(self):
+        with pytest.raises(ImportError):
+            ConfigParser.resolve_package_path("non_existent_module:foo.py")
 
-            monkeypatch.setattr(asset, "load", load)
-
+    def test_include_package_file(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # define paths
+            module_dir = os.path.join(temp_dir, 'my_module')
+            module_conf = os.path.join(module_dir, 'my.conf')
+            # create the module folder and necessary files (__init__ and config)
+            os.mkdir(module_dir)
+            open(os.path.join(module_dir, '__init__.py'), 'a').close()
+            with open(module_conf, 'w') as fdin:
+                fdin.write("{c: 3}")
+            # add the temp dir to sys.path so that 'my_module' can be discovered
+            monkeypatch.syspath_prepend(temp_dir)
+            # load the config and include the other config file from 'my_module'
             config = ConfigFactory.parse_string(
                 """
-                include package("dotted.name:asset/config_file")
+                a: 1
+                b: 2
+                include package("my_module:my.conf")
                 """
             )
-            assert config['a'] == 1
+            # check that the contents of both config files are available
+            assert dict(config.as_plain_ordered_dict()) == {'a': 1, 'b': 2, 'c': 3}
 
     def test_include_dict(self):
         expected_res = {


### PR DESCRIPTION
Currently we use the [`asset`](https://pypi.org/project/asset/) library in exactly [one place](https://github.com/chimpler/pyhocon/blob/c2fba83fb5a681342ebcfa5a74b53e6b02d9c459/pyhocon/config_parser.py#L352) to figure out the path to a file inside an installed module. The `asset` library is GPL licensed and brings with it a few more GPL dependencies. As pyhocon is Apache licensed, this causes issues for pyhocon users that cannot include software with strong copyleft licenses like the GPL.

Also, it introduces a lot of transitive dependencies:

```
pyhocon==0.3.56
  - asset [required: Any, installed: 0.6.13]
    - aadict [required: >=0.2.2, installed: 0.2.3]
      - six [required: >=1.6.0, installed: 1.15.0]
    - globre [required: >=0.1.5, installed: 0.1.5]
    - six [required: >=1.10.0, installed: 1.15.0]
  - pyparsing [required: >=2.0.3, installed: 2.4.7]
```

Without `asset`, this would be reduced to

```
pyhocon==0.3.56
  - pyparsing [required: >=2.0.3, installed: 2.4.7]
```

In this PR I re-implemented the functionality of the `asset.load()` function so we can avoid using the `asset` library in the first place.

The implementation is really basic, because it relies on [`imp.find_module`](https://docs.python.org/3/library/imp.html#imp.find_module) from the standard library. I would have preferred to use [`importlib.util.find_spec`](https://docs.python.org/3/library/importlib.html#importlib.util.find_spec), but it's not available in Python 2.7. I also added a bunch of tests (the previous test was pretty much non-functional because it mocked the result of `asset.load`).

Solves #234 