### PR TITLE
Add support for Python 3.9 and fix deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
 before_install: pip install --upgrade setuptools
 install: pip install tox tox-travis coveralls
 before_script: if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then tox -e flake8; fi

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8'
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     packages=[
         'pyhocon',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py{27,34,35,36,37,38}
+envlist = flake8, py{27,34,35,36,37,38,39}
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
The library is compatible with Python 3.9. I just enabled the tests in Tox and added a classifier string.

The second improvement is a fix for: https://github.com/chimpler/pyhocon/issues/248