### PR TITLE
Fix duration parsing in lists

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -750,9 +750,26 @@ class ListParser(TokenConverter):
         :param token_list:
         :return:
         """
-        cleaned_token_list = [token for tokens in (token.tokens if isinstance(token, ConfigInclude) else [token]
-                                                   for token in token_list if token != '')
-                              for token in tokens]
+        cleaned_token_list = []
+        # Note that a token can be a duration value object:
+        # >>> relativedelta(hours = 1) == ''
+        # False
+        # >>> relativedelta(hours = 1) != ''
+        # False
+        # relativedelta.__eq__() raises NotImplemented if it is compared with
+        # a different object type so Python falls back to identity comparison.
+        # We cannot compare this object to a string object.
+        for token in token_list:
+            if isinstance(token, str) and token == '':
+                # This is the case when there was a trailing comma in the list.
+                # The last token is just an empty string so we can safely ignore
+                # it.
+                continue
+            if isinstance(token, ConfigInclude):
+                cleaned_token_list.extend(token.tokens)
+            else:
+                cleaned_token_list.append(token)
+
         config_list = ConfigList(cleaned_token_list)
         return [config_list]
 

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -148,6 +148,16 @@ class TestConfigParser(object):
         )
         assert config['b'] == period(weeks=10)
 
+    def test_parse_with_list_mixed_types_with_durations_and_trailing_comma(self):
+        config = ConfigFactory.parse_string(
+            """
+            a: foo
+            b: [a, 1, 10 weeks, 5 minutes,]
+            c: bar
+            """
+        )
+        assert config['b'] == ['a', 1, period(weeks=10), period(minutes=5)]
+
     def test_parse_with_enclosing_square_bracket(self):
         config = ConfigFactory.parse_string("[1, 2, 3]")
         assert config == [1, 2, 3]


### PR DESCRIPTION
There are two changes:
 * Replace regex with `pyparsing` objects. Most important is `Or()` operator that matches the longest match.
 * Fix a bug in `ListParser.postParse()` that ignored some object types.

This fixes: https://github.com/chimpler/pyhocon/issues/252