### PR TITLE
#256 - Process substitution overrides in order

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -619,9 +619,10 @@ class ConfigParser(object):
                 if transformation is None and not is_optional_resolved \
                 else transformation
 
+            # When the result is None, remove the key.
             if result is None and config_values.key in config_values.parent:
                 del config_values.parent[config_values.key]
-            else:
+            elif result is not None:
                 config_values.parent[config_values.key] = result
                 s = cls._find_substitutions(result)
                 if s:
@@ -670,6 +671,12 @@ class ConfigParser(object):
                 _substitutions = substitutions[:]
 
                 for substitution in _substitutions:
+                    # If this substitution is an override, and the parent is still being processed,
+                    # skip this entry, it will be processed on the next loop.
+                    if substitution.parent.overriden_value:
+                        if substitution.parent.overriden_value in [s.parent for s in substitutions]:
+                            continue
+
                     is_optional_resolved, resolved_value = cls._resolve_variable(config, substitution)
 
                     # if the substitution is optional
@@ -695,6 +702,8 @@ class ConfigParser(object):
 
                     unresolved, new_substitutions, result = cls._do_substitute(substitution, resolved_value, is_optional_resolved)
                     any_unresolved = unresolved or any_unresolved
+                    # Detected substitutions may already be listed to process
+                    new_substitutions = [n for n in new_substitutions if n not in substitutions]
                     substitutions.extend(new_substitutions)
                     if not isinstance(result, ConfigValues):
                         substitutions.remove(substitution)

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -473,9 +473,12 @@ class ConfigValues(object):
         return len(self.get_substitutions()) > 0
 
     def get_substitutions(self):
+        # Returns a list of ConfigSubstitution tokens, in string order
         lst = []
         node = self
         while node:
+            # walking up the override chain and append overrides to the front.
+            # later, parent overrides will be processed first, followed by children
             lst = [token for token in node.tokens if isinstance(token, ConfigSubstitution)] + lst
             if hasattr(node, 'overriden_value'):
                 node = node.overriden_value

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1427,6 +1427,20 @@ class TestConfigParser(object):
         assert config['database.name'] == 'peopledb'
         assert config['database.pass'] == 'peoplepass'
 
+    def test_substitution_multiple_override(self):
+        config = ConfigFactory.parse_string(
+            """
+            a: 1
+            b: foo
+            c: ${a} ${b}
+            c: ${b} ${a}
+            d: ${a} ${b}
+            d: ${a} bar
+            """)
+
+        assert config['c'] == 'foo 1'
+        assert config['d'] == '1 bar'
+
     def test_substitution_nested_override(self):
         config = ConfigFactory.parse_string(
             """


### PR DESCRIPTION
Fixing #256 - and a small radius around it.

## The Scenario
Using hocon in a larger system where this came up.

```
keys: { something: "${lookup}-${name}" }

overridden by:
keys: { something: "${lookup}-legacy-name" }
```
During substitution & replacement, the following happened:

Starting queue had these substitutions: [${lookup}(parent), ${name}(parent), ${lookup}(child)]
1. Process `${lookup}(parent)`, the result value still had -${name}, so this substitution stays in the set to re-process, and enqueues ${name}(2) at the end of the list.
2. Process `${name}(parent)` - this produces a static result string, and is removed.
3. Process `${lookup}(child)` - this produces a static result string, and is removed.
(that's all the substitutions, so the loop restarts)
4. Process `${lookup}(parent)` - overwrites step 3. No overrides remain, so is removed.
5. Process `${name}(2)` - also overwrites step 3. No overrides remain, so is removed.

## Proposed Fix:

When looking at a substitution, first check if it has a parent override, and if that parent is active in the substitution list.  Wait for all parents to complete before processing the substitution.

This caused two test failures:
- `g: ${?missing1} ${?missing2}` would be alternatively added or removed from config as the substitutions processed.  This diff changes _do_substitute to only write/add a value if the value is not None.
- At step 3 above, if lookup is not processed, this is detected as a config loop, because the set of substitutions to evaluate is the same after the loop (${name} is added once and removed once).  To get around this, I added a second check to avoid re-queueing substitutions that are already being processed.

## Testing
- [x] Added new test case
- [x] Passed all tests (except NamedTemporaryFile)
- [ ] NamedTemporaryFile

^ NamedTemporaryFile does not work on Windows ([python.org](https://bugs.python.org/issue14243)) - I'll try to kick the tires in docker if there's traction for landing this.