### PR TITLE
adding the resolve method to resolve substitution keys in 1 config tree with another config tree

### DIFF
--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -67,6 +67,32 @@ class ConfigTree(OrderedDict):
 
         return a
 
+
+    def resolve(self, other):
+        """Merge config b into a
+        :param self: target config
+        :type self: ConfigTree
+        :param other: providing config
+        :type other: ConfigTree
+        :return: resolved config
+        """
+        copyA = copy.deepcopy(self)
+        def loop(tree):
+            for key, value in tree.items():
+                if isinstance(value, ConfigTree):
+                    loop(tree[key])
+                else:
+                    if isinstance(value, ConfigValues):
+                        for token in value.tokens:
+                            if isinstance(token, ConfigSubstitution):
+                                v = other.get(token.variable, NoneValue)
+                                if v is not None:
+                                    tree[key] = copy.deepcopy(v)
+                                if isinstance(tree[key], ConfigTree):
+                                    tree[key].parent = tree
+            return tree
+        return loop(copyA)
+
     def _put(self, key_path, value, append=False):
         key_elt = key_path[0]
         if len(key_path) == 1:

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from pyhocon.config_tree import ConfigTree, NoneValue
 from pyhocon.exceptions import (
     ConfigMissingException, ConfigWrongTypeException, ConfigException)
-from pyhocon.config_parser import ConfigFactory
+from pyhocon.config_parser import ConfigFactory, NO_SUBSTITUTION
 from pyhocon.tool import HOCONConverter
 
 
@@ -322,3 +322,31 @@ class TestConfigTree(object):
             assert escaped_key in hocon_tree
             parsed_tree = ConfigFactory.parse_string(hocon_tree)
             assert parsed_tree.get(key) == "value"
+
+    def test_config_tree_resolve(self):
+        config = ConfigFactory.parse_string(
+            """
+            a = ${sub}
+            nested {
+                value = ${nested.sub}
+            }
+            """,
+            resolve = False
+        )
+
+        substitudeConfig = ConfigFactory.parse_string(
+            """
+            sub = 100
+            nested {
+                sub = {
+                    a: "string"
+                    b: 10
+                }
+            }
+            """
+        )
+        result = config.resolve(substitudeConfig)
+        assert result.get_int('a') == 100
+        assert result.get_string('nested.value.a') == "string"
+        assert result.get_int('nested.value.b') == 10
+        assert config != result


### PR DESCRIPTION
The main difference is that with a fallback you merge the 2 configs into a super config.
With a resolve you only fill in the keys that where are not resolved in the config file. 