### PR TITLE
Update pyparsing requires lock to be more strict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     packages=[
         'pyhocon',
     ],
-    install_requires=['pyparsing>=2.0.3'],
+    install_requires=['pyparsing~=2.0'],
     extras_require={
         'Duration': ['python-dateutil>=2.8.0']
     },


### PR DESCRIPTION
## Summary

Update `pyparsing` `install_requires` lock in `setup.py` to be more strict and prevent installing `pyparsing>=3` when installing `pyhocon`.

The recent `pyparsing` [v3 release ](https://github.com/pyparsing/pyparsing/releases/tag/pyparsing_3.0.0b3) dropped support for Python 3.5. Without this change, running `pyhocon` on Python 3.5 can result in `SyntaxError` errors.
