### PR TITLE
WIP: #281: Fixes for lists expansion operator (`+=`)

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -535,7 +535,10 @@ class ConfigParser(object):
         """
         variable = substitution.variable
         try:
-            return True, config.get(variable)
+            if substitution.self_ref:
+                return True, substitution.parent.overriden_value
+            else:
+                return True, config.get(variable)
         except ConfigMissingException:
             # default to environment variable
             value = os.environ.get(variable)
@@ -859,10 +862,10 @@ class ConfigTreeParser(TokenConverter):
                 else:
                     value = values[0]
                     if isinstance(value, list) and operator == "+=":
-                        value = ConfigValues([ConfigSubstitution(key, True, '', False, loc), value], False, loc)
+                        value = ConfigValues([ConfigSubstitution(key, True, '', False, loc, self_ref=True), value], False, loc)
                         config_tree.put(key, value, False)
                     elif isinstance(value, unicode) and operator == "+=":
-                        value = ConfigValues([ConfigSubstitution(key, True, '', True, loc), ' ' + value], True, loc)
+                        value = ConfigValues([ConfigSubstitution(key, True, '', True, loc, self_ref=True), ' ' + value], True, loc)
                         config_tree.put(key, value, False)
                     elif isinstance(value, list):
                         config_tree.put(key, value, False)

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -602,7 +602,7 @@ class ConfigValues(object):
 
 
 class ConfigSubstitution(object):
-    def __init__(self, variable, optional, ws, instring, loc):
+    def __init__(self, variable, optional, ws, instring, loc, self_ref=False):
         self.variable = variable
         self.optional = optional
         self.ws = ws
@@ -610,6 +610,7 @@ class ConfigSubstitution(object):
         self.parent = None
         self.instring = instring
         self.loc = loc
+        self.self_ref = self_ref
 
     def raw_str(self):
         return self.variable

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -816,6 +816,17 @@ class TestConfigParser(object):
         )
         assert config.get("x") == [1, 2, 3, 4]
 
+    def test_self_append_array_inside_dict(self):
+        config = ConfigFactory.parse_string(
+            """
+            d {
+                x = [1,2]
+                x += [3,4]
+            }
+            """
+        )
+        assert config.get("d.x") == [1, 2, 3, 4]
+
     def test_self_append_string(self):
         '''
         Should be equivalent to
@@ -829,6 +840,22 @@ class TestConfigParser(object):
             """
         )
         assert config.get("x") == "abc def"
+
+    def test_self_append_string_inside_dict(self):
+        '''
+        Should be equivalent to
+        x = abc
+        x = ${?x} def
+        '''
+        config = ConfigFactory.parse_string(
+            """
+            d {
+                x = abc
+                x += def
+            }
+            """
+        )
+        assert config.get("d.x") == "abc def"
 
     def test_self_append_non_existent_string(self):
         '''
@@ -857,6 +884,17 @@ class TestConfigParser(object):
             """
         )
         assert config.get("x") == {'a': 1, 'b': 2}
+
+    def test_self_append_object_inside_dict(self):
+        config = ConfigFactory.parse_string(
+            """
+            d {
+                x = {a: 1}
+                x += {b: 2}
+            }
+            """
+        )
+        assert config.get("d.x") == {'a': 1, 'b': 2}
 
     def test_self_append_nonexistent_object(self):
         config = ConfigFactory.parse_string(


### PR DESCRIPTION
### Root Casuse
Actually, the `+=` operator took the HOCON definition *too* literally.
When the `x += y` was met, it created a substitution for `x`.
Then, when the entire config is read, that substitution is applied at the exact name `x`.
However, if `x` was inside a dict object, the `x` would not be resolved.

### Changes
* Added tests covering broken operator behavior
* The `+=` operator now creates a smarter substitution

### ToDo:
[ ] Check other conditions when it may fail
[ ] (?) Resolve `+=` in-place?
