### PR TITLE
Fix: Tests on Windows

### DIFF
--- a/pyhocon/converter.py
+++ b/pyhocon/converter.py
@@ -125,7 +125,7 @@ class HOCONConverter(object):
             if '\n' in config and len(config) > 1:
                 lines = '"""{value}"""'.format(value=config)  # multilines
             else:
-                lines = '"{value}"'.format(value=cls.__escape_string(config))
+                lines = '"{value}"'.format(value=cls._escape_string(config))
         elif isinstance(config, ConfigValues):
             lines = ''.join(cls.to_hocon(o, compact, indent, level) for o in config.tokens)
         elif isinstance(config, ConfigSubstitution):
@@ -137,7 +137,7 @@ class HOCONConverter(object):
             if '\n' in config.value and len(config.value) > 1:
                 lines = '"""{value}"""'.format(value=config.value)  # multilines
             else:
-                lines = '"{value}"'.format(value=cls.__escape_string(config.value))
+                lines = '"{value}"'.format(value=cls._escape_string(config.value))
         elif cls._is_timedelta_like(config):
             lines += cls._timedelta_to_hocon(config)
         elif config is None or isinstance(config, NoneValue):
@@ -276,7 +276,7 @@ class HOCONConverter(object):
                 fd.write(res)
 
     @classmethod
-    def __escape_match(cls, match):
+    def _escape_match(cls, match):
         char = match.group(0)
         return {
             '\b': r'\b',
@@ -289,8 +289,8 @@ class HOCONConverter(object):
         }.get(char) or (r'\u%04x' % ord(char))
 
     @classmethod
-    def __escape_string(cls, string):
-        return re.sub(r'[\x00-\x1F"\\]', cls.__escape_match, string)
+    def _escape_string(cls, string):
+        return re.sub(r'[\x00-\x1F"\\]', cls._escape_match, string)
 
     @classmethod
     def _is_timedelta_like(cls, config):


### PR DESCRIPTION
### Changed API:
 * `HOCONConverter.__escape_string() / .escape_match()` methods are now protected instead of private

### Changed Tests:
 * Temporary files are closed before being passed to the library
   (and then carefully deleted)
 * Temporary file names are properly escaped
 * `file://` URLs are properly escaped by using `urllib.pathname2url()`
 * When writing a file with a multiline string, now uses binary IO instead of text IO to prevent line breaks mess
