### PR TITLE
#272: Fixes for dict substitution

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -125,6 +125,10 @@ def period(period_value, period_unit):
     return period_impl(**arguments)
 
 
+U_KEY_SEP = unicode('.')
+U_KEY_FMT = unicode('"{0}"')
+
+
 class ConfigFactory(object):
 
     @classmethod
@@ -868,6 +872,14 @@ class ConfigTreeParser(TokenConverter):
                         config_tree.put(key, value, False)
                     else:
                         existing_value = config_tree.get(key, None)
+                        parsed_key = ConfigTree.parse_key(key)
+                        key = parsed_key[0]
+                        if len(parsed_key) > 1:
+                            # Special case when the key contains path (i.e., `x.y = v`)
+                            new_value = ConfigTree()
+                            new_value.put(U_KEY_SEP.join(U_KEY_FMT.format(k) for k in parsed_key[1:]), value)
+                            value = new_value
+
                         if isinstance(value, ConfigTree) and not isinstance(existing_value, list):
                             # Only Tree has to be merged with tree
                             config_tree.put(key, value, True)

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -19,7 +19,6 @@ try:
 except Exception:
     from datetime import timedelta as period
 
-
 class TestConfigParser(object):
     def test_parse_simple_value(self):
         config = ConfigFactory.parse_string(
@@ -605,6 +604,58 @@ class TestConfigParser(object):
             'name': 'east',
             'cluster-size': 6
         }
+
+    def test_dict_substitutions2(self):
+        config = ConfigFactory.parse_string(
+            """
+                data-center-generic = { cluster-size = 6 }
+                data-center-east = ${data-center-generic}
+                data-center-east.name = "east"
+            """
+        )
+
+        assert config.get('data-center-east.cluster-size') == 6
+        assert config.get('data-center-east.name') == 'east'
+
+        config2 = ConfigFactory.parse_string(
+            """
+                data-center-generic = { cluster-size = 6 }
+                data-center-east.name = "east"
+                data-center-east = ${data-center-generic}
+            """
+        )
+
+        assert config2.get('data-center-east.cluster-size') == 6
+        assert config2.get('data-center-east.name') == 'east'
+
+        config3 = ConfigFactory.parse_string(
+            """
+                data-center-generic = { cluster-size = 6 }
+                data-center-east.name = "east"
+                data-center-east = ${data-center-generic}
+                data-center-east.cluster-size = 9
+                data-center-east.opts = "-Xmx4g"
+            """
+        )
+
+        assert config3.get('data-center-east.cluster-size') == 9
+        assert config3.get('data-center-east.name') == 'east'
+        assert config3.get('data-center-east.opts') == '-Xmx4g'
+
+        config4 = ConfigFactory.parse_string(
+            """
+                data-center-generic = { cluster-size = 6 }
+                data-center-east.name = "east"
+                data-center-east = ${data-center-generic}
+                data-center-east-prod = ${data-center-east}
+                data-center-east-prod.tmpDir=/tmp
+            """
+        )
+
+        assert config4.get('data-center-east.cluster-size') == 6
+        assert config4.get('data-center-east.name') == 'east'
+        assert config4.get('data-center-east-prod.cluster-size') == 6
+        assert config4.get('data-center-east-prod.tmpDir') == '/tmp'
 
     def test_dos_chars_with_unquoted_string_noeol(self):
         config = ConfigFactory.parse_string("foo = bar")


### PR DESCRIPTION
Closes #272 

### Root Cause
In `ConfigTreePatser.postParse()`, where the value is put to the resulting dict, the key was not split. Thus, `ConfigTree.put()` was overwriting any values.

### Changes
 * Added tests for that case
 * `ConfigTreePatser.postParse()` now splits the key before calling `ConfigTree.put()`
