### PR TITLE
Update pyparsing requirement from ~=2.0 to >=2,<4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,10 @@ setup(
     packages=[
         'pyhocon',
     ],
-    install_requires=['pyparsing~=2.0'],
+    install_requires=[
+        'pyparsing~=2.0;python_version<"3.0"',
+        'pyparsing>=2,<4;python_version>="3.0"',
+    ],
     extras_require={
         'Duration': ['python-dateutil>=2.8.0']
     },


### PR DESCRIPTION
Do so only for Python 3 since pyparsing 3 dropped support for Python 2

Replaces https://github.com/chimpler/pyhocon/pull/276