### PR TITLE
Carolguo/fix override

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -659,8 +659,6 @@ class ConfigParser(object):
                         continue
 
                     cache_values = []
-                    if isinstance(resolved_value, ConfigValues):
-                        cache_values.append(substitution)
 
                     if isinstance(overridden_value, ConfigValues):
                         cache_values = cache.get(substitution)

--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -38,11 +38,11 @@ from pyhocon.exceptions import (ConfigException, ConfigMissingException,
 use_urllib2 = False
 try:
     # For Python 3.0 and later
-    from urllib.request import urlopen
     from urllib.error import HTTPError, URLError
+    from urllib.request import urlopen
 except ImportError:  # pragma: no cover
     # Fall back to Python 2's urllib2
-    from urllib2 import urlopen, HTTPError, URLError
+    from urllib2 import HTTPError, URLError, urlopen
 
     use_urllib2 = True
 try:
@@ -644,9 +644,11 @@ class ConfigParser(object):
                         continue
 
                     is_optional_resolved, resolved_value = cls._resolve_variable(config, substitution)
-                    if isinstance(resolved_value, ConfigValues) and overridden_value and not isinstance(
-                            overridden_value, ConfigValues):
-                        unresolved, _, _ = cls._do_substitute(substitution, overridden_value, is_optional_resolved)
+                    if isinstance(resolved_value, ConfigValues) :
+                        value_to_be_substitute = resolved_value
+                        if overridden_value and not isinstance(overridden_value, ConfigValues):
+                                value_to_be_substitute = overridden_value
+                        unresolved, _, _ = cls._do_substitute(substitution, value_to_be_substitute, is_optional_resolved)
                         any_unresolved = unresolved or any_unresolved
                         if not unresolved and substitution in substitutions:
                             substitutions.remove(substitution)
@@ -657,6 +659,9 @@ class ConfigParser(object):
                         continue
 
                     cache_values = []
+                    if isinstance(resolved_value, ConfigValues):
+                        cache_values.append(substitution)
+
                     if isinstance(overridden_value, ConfigValues):
                         cache_values = cache.get(substitution)
                         if cache_values is None:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ class PyTestCommand(TestCommand):
 
 setup(
     name='pyhocon',
-    version='0.3.59',
+    version='0.3.61',
     description='HOCON parser for Python',
     long_description='pyhocon is a HOCON parser for Python. Additionally we provide a tool (pyhocon) to convert any HOCON '
                      'content into json, yaml and properties format.',

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1454,7 +1454,6 @@ class TestConfigParser(object):
                 """.format(tmp_file=incl_name)
             )
             assert config3['a'] == expected_res
-
         finally:
             os.remove(incl_name)
 

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -14,10 +14,12 @@ except ImportError:
     # Python 2
     from urllib import pathname2url
 
-from pyparsing import ParseBaseException, ParseException, ParseSyntaxException
 import mock
 import pytest
-from pyhocon import (ConfigFactory, ConfigParser, ConfigSubstitutionException, ConfigTree, HOCONConverter)
+from pyparsing import ParseBaseException, ParseException, ParseSyntaxException
+
+from pyhocon import (ConfigFactory, ConfigParser, ConfigSubstitutionException,
+                     ConfigTree, HOCONConverter)
 from pyhocon.exceptions import (ConfigException, ConfigMissingException,
                                 ConfigWrongTypeException)
 
@@ -1452,7 +1454,7 @@ class TestConfigParser(object):
                 """.format(tmp_file=incl_name)
             )
             assert config3['a'] == expected_res
-        
+
         finally:
             os.remove(incl_name)
 
@@ -1712,6 +1714,21 @@ class TestConfigParser(object):
             'num': 3,
             'retries_msg': 'You have 3 retries'
         }
+
+    def test_override_optional_substitution(self):
+        config = ConfigFactory.parse_string(
+            """
+              a = 3
+              test = ${a}
+              test = ${?b}
+              result = ${test}
+            """)
+        assert config == {
+            'a' : 3,
+            'test': 3,
+            'result': 3
+        }
+
 
     def test_substitution_cycle(self):
         with pytest.raises(ConfigSubstitutionException):


### PR DESCRIPTION
0.3.60 has introduced another problem.
```
{
     a = 3
    test = ${a}
    test = ${?b}
    result = ${test}
}
```
this used to work in 0.3.59 version, but now it breaks with
```
  File "/Users/carol.guo/.pyenv/versions/3.9.7/lib/python3.9/site-packages/pyhocon/config_parser.py", line 695, in resolve_substitutions
    raise ConfigSubstitutionException("Cannot resolve {variables}. Check for cycles.".format(
pyhocon.exceptions.ConfigSubstitutionException: Cannot resolve ${test}: (line: 7, col: 21). Check for cycles.
```