### PR TITLE
Spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,7 +265,7 @@
 
 # Version 0.3.4
 
-* Fixed substitutions that are overriden later on by a non substitution. PR[#34]
+* Fixed substitutions that are overridden later on by a non substitution. PR[#34]
 * Added logging. PR[#30] and PR[#31]
 
 # Version 0.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,7 +271,7 @@
 # Version 0.3.3
 
 * Fixed optional substitution when overriding elements at the same level. PR[#28]
-* Silent IOErrors when including non-existent files. PR[#24]
+* Silent IOErrors when including nonexistent files. PR[#24]
 * Fixed when assign key to a value, list or dict that starts with eol. PR[#22]
 
 ## Version 0.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,7 +227,7 @@
 
 # Version 0.3.13
 
-* Fixed dictionary substititution merge. PR[#52]
+* Fixed dictionary substitution merge. PR[#52]
 
 # Version 0.3.12
 

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ assert config == d
   - Scott Johnson ([@scottj97](https://github.com/scottj97))
   - Yifei Tao ([@yifeitao](https://github.com/yifeitao))
   - Kevin Fong ([@KevinMFong](https://github.com/KevinMFong))
-  - Erik Cederstrand [@ecederstrand](https://github.com/ecederstrand))
+  - Erik Cederstrand ([@ecederstrand](https://github.com/ecederstrand))
 
 ### Thanks
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ password = conf.get('databases.mysql.password', 'default_password') #  use defau
       # you can use substitution with unquoted strings
       retries_msg = You have ${databases.mysql.retries} retries
 
-      # retries message will be overriden if environment variable CUSTOM_MSG is set
+      # retries message will be overridden if environment variable CUSTOM_MSG is set
       retries_msg = ${?CUSTOM_MSG}
     }
 

--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -130,7 +130,7 @@ class ConfigFactory(object):
         :param resolve: if true, resolve substitutions
         :type resolve: boolean
         :param unresolved_value: assigned value to unresolved substitution.
-        If overriden with a default value, it will replace all unresolved values by the default value.
+        If overridden with a default value, it will replace all unresolved values by the default value.
         If it is set to pyhocon.STR_SUBSTITUTION then it will replace the value by its substitution expression (e.g., ${x})
         :type unresolved_value: class
         :return: Config object or []
@@ -155,7 +155,7 @@ class ConfigFactory(object):
         :param resolve: if true, resolve substitutions
         :type resolve: boolean
         :param unresolved_value: assigned value to unresolved substitution.
-        If overriden with a default value, it will replace all unresolved values by the default value.
+        If overridden with a default value, it will replace all unresolved values by the default value.
         If it is set to pyhocon.STR_SUBSTITUTION then it will replace the value by its substitution expression (e.g., ${x})
         :type unresolved_value: class
         :return: Config object or []
@@ -183,7 +183,7 @@ class ConfigFactory(object):
         :param resolve: if true, resolve substitutions
         :type resolve: boolean
         :param unresolved_value: assigned value to unresolved substitution.
-        If overriden with a default value, it will replace all unresolved values by the default value.
+        If overridden with a default value, it will replace all unresolved values by the default value.
         If it is set to pyhocon.STR_SUBSTITUTION then it will replace the value by its substitution expression (e.g., ${x})
         :type unresolved_value: class
         :return: Config object
@@ -240,7 +240,7 @@ class ConfigParser(object):
         :param resolve: if true, resolve substitutions
         :type resolve: boolean
         :param unresolved_value: assigned value to unresolved substitution.
-        If overriden with a default value, it will replace all unresolved values by the default value.
+        If overridden with a default value, it will replace all unresolved values by the default value.
         If it is set to pyhocon.STR_SUBSTITUTION then it will replace the value by its substitution expression (e.g., ${x})
         :type unresolved_value: boolean
         :return: a ConfigTree or a list
@@ -580,7 +580,7 @@ class ConfigParser(object):
             # use a deepcopy of resolved_value to avoid mutation
             config_values.put(substitution.index, copy.deepcopy(formatted_resolved_value))
             transformation = config_values.transform()
-            result = config_values.overriden_value \
+            result = config_values.overridden_value \
                 if transformation is None and not is_optional_resolved \
                 else transformation
 
@@ -635,7 +635,7 @@ class ConfigParser(object):
 
                 for substitution in _substitutions:
                     unresolved = False
-                    overridden_value = substitution.parent.overriden_value
+                    overridden_value = substitution.parent.overridden_value
                     if isinstance(overridden_value, ConfigValues):
                         overridden_value = overridden_value.transform()
                     # If this substitution is an override, and the parent is still being processed,
@@ -663,7 +663,7 @@ class ConfigParser(object):
                             continue
                     if not isinstance(resolved_value, ConfigValues):
                         cache_values.append(substitution)
-                        overrides = [s for s in substitutions if s.parent.overriden_value == substitution.parent]
+                        overrides = [s for s in substitutions if s.parent.overridden_value == substitution.parent]
                         if len(overrides) > 0:
                             for o in overrides:
                                 values = cache.get(o) if cache.get(o) is not None else []

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -144,7 +144,7 @@ class ConfigTree(OrderedDict):
                             type=l_value.__class__.__name__)
                     )
             else:
-                # if there was an override keep overide value
+                # if there was an override keep override value
                 if isinstance(value, ConfigValues):
                     value.parent = self
                     value.key = key_elt

--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -57,7 +57,7 @@ class ConfigTree(OrderedDict):
                     value.parent = a
                     value.key = key
                     if key in a:
-                        value.overriden_value = a[key]
+                        value.overridden_value = a[key]
                 a[key] = value
                 if a.root:
                     if b.root:
@@ -115,7 +115,7 @@ class ConfigTree(OrderedDict):
                     l_value.tokens.append(value)
                     l_value.recompute()
                 elif isinstance(l_value, ConfigTree) and isinstance(value, ConfigValues):
-                    value.overriden_value = l_value
+                    value.overridden_value = l_value
                     value.tokens.insert(0, l_value)
                     value.recompute()
                     value.parent = self
@@ -124,7 +124,7 @@ class ConfigTree(OrderedDict):
                     self[key_elt] = value
                 elif isinstance(l_value, list) and isinstance(value, ConfigValues):
                     self._push_history(key_elt, value)
-                    value.overriden_value = l_value
+                    value.overridden_value = l_value
                     value.parent = self
                     value.key = key_elt
                     self[key_elt] = value
@@ -148,7 +148,7 @@ class ConfigTree(OrderedDict):
                 if isinstance(value, ConfigValues):
                     value.parent = self
                     value.key = key_elt
-                    value.overriden_value = self.get(key_elt, None)
+                    value.overridden_value = self.get(key_elt, None)
                 self._push_history(key_elt, value)
                 self[key_elt] = value
         else:
@@ -477,7 +477,7 @@ class ConfigValues(object):
         self.key = None
         self._instring = instring
         self._loc = loc
-        self.overriden_value = None
+        self.overridden_value = None
         self.recompute()
 
     def recompute(self):
@@ -506,8 +506,8 @@ class ConfigValues(object):
             # walking up the override chain and append overrides to the front.
             # later, parent overrides will be processed first, followed by children
             lst = [token for token in node.tokens if isinstance(token, ConfigSubstitution)] + lst
-            if hasattr(node, 'overriden_value'):
-                node = node.overriden_value
+            if hasattr(node, 'overridden_value'):
+                node = node.overridden_value
                 if not isinstance(node, ConfigValues):
                     break
             else:
@@ -549,8 +549,8 @@ class ConfigValues(object):
 
         if first_tok_type is ConfigTree:
             child = []
-            if hasattr(self, 'overriden_value'):
-                node = self.overriden_value
+            if hasattr(self, 'overridden_value'):
+                node = self.overridden_value
                 while node:
                     if isinstance(node, ConfigValues):
                         value = node.transform()
@@ -562,8 +562,8 @@ class ConfigValues(object):
                         child.append(node)
                     else:
                         break
-                    if hasattr(node, 'overriden_value'):
-                        node = node.overriden_value
+                    if hasattr(node, 'overridden_value'):
+                        node = node.overridden_value
                     else:
                         break
 

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -2488,7 +2488,7 @@ www.example-ö.com {
             config.get_string(u'www.example-ö.com.us.name.missing')
 
     def test_with_comment_on_last_line(self):
-        # Adress issue #102
+        # Address issue #102
         config_tree = ConfigFactory.parse_string("""
         foo: "1"
         bar: "2"
@@ -2514,7 +2514,7 @@ www.example-ö.com {
         assert expected == config_tree
 
     def test_merge_overriden(self):
-        # Adress issue #110
+        # Address issue #110
         # ConfigValues must merge with its .overriden_value
         # if both are ConfigTree
         config_tree = ConfigFactory.parse_string("""

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -2513,9 +2513,9 @@ www.example-ö.com {
         }
         assert expected == config_tree
 
-    def test_merge_overriden(self):
+    def test_merge_overridden(self):
         # Address issue #110
-        # ConfigValues must merge with its .overriden_value
+        # ConfigValues must merge with its .overridden_value
         # if both are ConfigTree
         config_tree = ConfigFactory.parse_string("""
         foo: ${bar}

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -334,7 +334,7 @@ class TestConfigTree(object):
             resolve=False
         )
 
-        substitudeConfig = ConfigFactory.parse_string(
+        substituteConfig = ConfigFactory.parse_string(
             """
             sub = 100
             nested {
@@ -345,7 +345,7 @@ class TestConfigTree(object):
             }
             """
         )
-        result = config.resolve(substitudeConfig)
+        result = config.resolve(substituteConfig)
         assert result.get_int('a') == 100
         assert result.get_string('nested.value.a') == "string"
         assert result.get_int('nested.value.b') == 10


### PR DESCRIPTION
Fixes misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/pyhocon/actions/runs/6124974527/attempts/1#summary-16626031396

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/pyhocon/actions/runs/6124974600/attempts/1#summary-16626031688