### PR TITLE
fix(config_parser): handle substitutions with resolved values of type ConfigValues

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -661,7 +661,8 @@ class ConfigParser(object):
                         cache_values = cache.get(substitution)
                         if cache_values is None:
                             continue
-                    if not isinstance(resolved_value, ConfigValues):
+
+                    if resolved_value:
                         cache_values.append(substitution)
                         overrides = [s for s in substitutions if s.parent.overriden_value == substitution.parent]
                         if len(overrides) > 0:

--- a/samples/substitutions.d/base.conf
+++ b/samples/substitutions.d/base.conf
@@ -1,0 +1,12 @@
+foo {
+  foo-inner {
+    pre-foo = 1
+    foo-sub = ${foo.foo-inner.pre-foo}${foo.foo-inner.bar}
+  }
+}
+
+bar {
+  bar-inner {
+    foo-sub = ${foo.foo-inner.foo-sub}
+  }
+}

--- a/samples/substitutions.d/child.conf
+++ b/samples/substitutions.d/child.conf
@@ -1,0 +1,7 @@
+include required("base.conf")
+
+foo {
+  foo-inner {
+    bar = 1
+  }
+}

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -2626,6 +2626,11 @@ www.example-ö.com {
         assert config == expected
         assert config == json.loads(source)
 
+    def test_nested_substitution(self):
+        config = ConfigFactory.parse_file("samples/substitutions.d/child.conf")
+        assert config.get_int("foo.foo-inner.foo-sub") == 11
+        assert config.get_int("bar.bar-inner.foo-sub") == 11
+
 
 try:
     from dateutil.relativedelta import relativedelta


### PR DESCRIPTION
This PR fixes #321, where substitutions are not correctly resolved when nested in subsections and having dependents from another config file.