### PR TITLE
Remove the deprecated test command from setuptools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,25 +3,6 @@
 import sys
 
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
-
-
-class PyTestCommand(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
 
 
 setup(
@@ -59,14 +40,9 @@ setup(
     extras_require={
         'Duration': ['python-dateutil>=2.8.0']
     },
-    tests_require=['pytest', 'mock==3.0.5'],
     entry_points={
         'console_scripts': [
             'pyhocon=pyhocon.tool:main'
         ]
     },
-    test_suite='tests',
-    cmdclass={
-        'test': PyTestCommand
-    }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = flake8, py{27,38,39,310,311,312}
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =
   pytest
+  mock==3.0.5
   coveralls
   python-dateutil>=2.8.0
   # for python 3.4


### PR DESCRIPTION
This PR removes the [long-deprecated](https://github.com/pypa/setuptools/issues/1684) test command from setup.