### PR TITLE
Fixed parsing for empty strings in lists getting dropped

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -755,11 +755,6 @@ class ListParser(TokenConverter):
         # a different object type so Python falls back to identity comparison.
         # We cannot compare this object to a string object.
         for token in token_list:
-            if isinstance(token, str) and token == '':
-                # This is the case when there was a trailing comma in the list.
-                # The last token is just an empty string so we can safely ignore
-                # it.
-                continue
             if isinstance(token, ConfigInclude):
                 cleaned_token_list.extend(token.tokens)
             else:

--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -754,6 +754,13 @@ class ListParser(TokenConverter):
         # relativedelta.__eq__() raises NotImplemented if it is compared with
         # a different object type so Python falls back to identity comparison.
         # We cannot compare this object to a string object.
+
+        # If the token list is a multiline list
+        # Remove the first and last tokens from token list which are new lines converted to empty strings
+        if instring[loc - 1] in ["\n", "\r"]:
+            token_list.pop(0)
+            token_list.pop(-1)
+
         for token in token_list:
             if isinstance(token, ConfigInclude):
                 cleaned_token_list.extend(token.tokens)


### PR DESCRIPTION
Replaced block of code skipping empty strings in lists with:

New block of code that pops empty string values in the first item and last item of a token list if that token list was generated from a multiline list. All other empty string values in lists are preserved and not dropped..

Fixes:
https://github.com/chimpler/pyhocon/issues/232
Related Issue:
https://github.com/chimpler/pyhocon/issues/317
