### PR TITLE
fix wrong parameter name

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -346,9 +346,9 @@ class ConfigParser(object):
 
         with set_default_white_spaces():
             assign_expr = Forward()
-            true_expr = Keyword("true", case_insensitive=True).set_parse_action(replace_with(True))
-            false_expr = Keyword("false", case_insensitive=True).set_parse_action(replace_with(False))
-            null_expr = Keyword("null", case_insensitive=True).set_parse_action(replace_with(NoneValue()))
+            true_expr = Keyword("true", caseless=True).set_parse_action(replace_with(True))
+            false_expr = Keyword("false", caseless=True).set_parse_action(replace_with(False))
+            null_expr = Keyword("null", caseless=True).set_parse_action(replace_with(NoneValue()))
             key = QuotedString('"""', esc_char='\\', unquote_results=False) | \
                 QuotedString('"', esc_char='\\', unquote_results=False) | Word(alphanums + alphas8bit + '._- /')
 
@@ -382,7 +382,7 @@ class ConfigParser(object):
                                  - Literal(')').suppress())
             )
             include_expr = (
-                Keyword("include", case_insensitive=True).suppress() + (
+                Keyword("include", caseless=True).suppress() + (
                     include_content | (
                         Keyword("required") - Literal('(').suppress() - include_content - Literal(')').suppress()
                     )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='pyhocon',
-    version='0.3.62',
+    version='0.3.63',
     description='HOCON parser for Python',
     long_description='pyhocon is a HOCON parser for Python. Additionally we provide a tool (pyhocon) to convert any HOCON '
                      'content into json, yaml and properties format.',


### PR DESCRIPTION
Solves the [issue 342](https://github.com/chimpler/pyhocon/issues/342) by correcting the parameter name. 

In some versions of pyparsing (e.g. 3.0.9) the currently latest version of pyhocon (`0.3.62`) causes a` TypeError: Keyword.__init__() got an unexpected keyword argument 'case_insensitive' `.