### PR TITLE
Escape multiline strings containing triple quotes in to_hocon

### DIFF
--- a/pyhocon/converter.py
+++ b/pyhocon/converter.py
@@ -115,7 +115,10 @@ class HOCONConverter(object):
                 lines += '\n'.join(bet_lines)
                 lines += '\n{indent}]'.format(indent=''.rjust((level - 1) * indent, ' '))
         elif isinstance(config, str):
-            if '\n' in config and len(config) > 1:
+            # A triple-quoted literal cannot contain the `"""` sequence (it
+            # would terminate the literal early), so such strings must use the
+            # escaped single-quoted form instead.
+            if '\n' in config and len(config) > 1 and '"""' not in config:
                 lines = '"""{value}"""'.format(value=config)  # multilines
             else:
                 lines = '"{value}"'.format(value=cls._escape_string(config))
@@ -127,7 +130,7 @@ class HOCONConverter(object):
                 lines += '?'
             lines += config.variable + '}' + config.ws
         elif isinstance(config, ConfigQuotedString):
-            if '\n' in config.value and len(config.value) > 1:
+            if '\n' in config.value and len(config.value) > 1 and '"""' not in config.value:
                 lines = '"""{value}"""'.format(value=config.value)  # multilines
             else:
                 lines = '"{value}"'.format(value=cls._escape_string(config.value))

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 from datetime import timedelta
 
-from pyhocon import ConfigTree
+from pyhocon import ConfigFactory, ConfigTree
 from pyhocon.converter import HOCONConverter
 
 
@@ -107,6 +107,16 @@ class TestConverterToHocon(object):
         assert 'a = """\nc"""' == to_hocon({'a': '\nc'})
         assert 'a = """b\n"""' == to_hocon({'a': 'b\n'})
         assert 'a = """\n\n"""' == to_hocon({'a': '\n\n'})
+
+    def test_format_multiline_string_with_triple_quote(self):
+        # A multiline string that itself contains `"""` cannot use the
+        # triple-quoted form (the embedded `"""` would terminate the literal
+        # early), so it must fall back to the escaped single-quoted form and
+        # still round-trip.
+        assert r'a = "a\nb\"\"\"c"' == to_hocon({'a': 'a\nb"""c'})
+        for value in ('a\nb"""c', 'before\n"""middle"""\nafter', '"""\nleading'):
+            parsed = ConfigFactory.parse_string(to_hocon({'a': value}))['a']
+            assert parsed == value
 
     def test_format_time_delta(self):
         for time_delta, expected_result in ((timedelta(days=0), 'td = 0 seconds'),


### PR DESCRIPTION
## Summary

`HOCONConverter.to_hocon` emits any string containing a newline as a triple-quoted (`"""..."""`) literal — even when the string itself contains a `"""` sequence. The embedded `"""` terminates the literal early, so the output either fails to re-parse or silently drops the `"""` markers, breaking the `to_hocon` → parse round-trip.

```python
from pyhocon import ConfigFactory
from pyhocon.converter import HOCONConverter

out = HOCONConverter.to_hocon(ConfigFactory.from_dict({"k": 'a\nb"""c'}))
# -> k = """a\nb"""c"""
ConfigFactory.parse_string(out)   # ParseException

out = HOCONConverter.to_hocon(ConfigFactory.from_dict({"k": 'before\n"""middle"""\nafter'}))
ConfigFactory.parse_string(out)["k"]   # silently 'before\nmiddle\nafter' — the """ markers dropped
```

`to_json` handles the identical values correctly, confirming the value is representable.

## Cause

In `to_hocon` (`pyhocon/converter.py`), both the `str` branch and the `ConfigQuotedString` branch chose the `"""..."""` form solely on the presence of a newline:

```python
if '\n' in config and len(config) > 1:
    lines = '"""{value}"""'.format(value=config)  # multilines
```

This ignores that a HOCON triple-quoted string cannot contain the `"""` sequence.

## Fix

Only use the triple-quoted form when the value does **not** contain `"""`; otherwise fall through to the existing escaped single-quoted path (`_escape_string`, which already escapes `\n` → `\n`). Applied to both branches. Normal multiline strings (no `"""`) are unchanged, preserving `test_format_multiline_string`.

## Verification

- Added `test_format_multiline_string_with_triple_quote`, which asserts the escaped output form and round-trips three `"""`-containing values through the parser. It fails before the fix and passes after.
- Full suite: **309 passed, 1 xfailed** (was 308 + 1 xfailed; no regressions). `flake8 pyhocon tests setup.py` exits 0.

This pull request was prepared with the assistance of AI, under my direction and review.
