### PR TITLE
Fix AttributeError on unresolved nested self-append (+=)

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -785,10 +785,10 @@ class ConfigTreeParser(TokenConverter):
                 else:
                     value = values[0]
                     if isinstance(value, list) and operator == "+=":
-                        value = ConfigValues([ConfigSubstitution(key, True, '', False, loc), value], False, loc)
+                        value = ConfigValues([ConfigSubstitution(key, True, '', instring, loc), value], instring, loc)
                         config_tree.put(key, value, False)
                     elif isinstance(value, str) and operator == "+=":
-                        value = ConfigValues([ConfigSubstitution(key, True, '', True, loc), ' ' + value], True, loc)
+                        value = ConfigValues([ConfigSubstitution(key, True, '', instring, loc), ' ' + value], instring, loc)
                         config_tree.put(key, value, False)
                     elif isinstance(value, list):
                         config_tree.put(key, value, False)

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -959,6 +959,15 @@ class TestConfigParser(object):
         )
         assert config.get("x") == {'a': 1}
 
+    def test_self_append_nonexistent_nested_key_reports_typed_error(self):
+        # an unresolved nested += must raise the typed error, not leak AttributeError
+        for content in ('x.y.z += ', 'a.b += def', 'a.b += [1,2]',
+                        'foo: {bar: []}\nfoo.bar += []'):
+            with pytest.raises(ConfigSubstitutionException) as exc_info:
+                ConfigFactory.parse_string(content)
+            message = str(exc_info.value)
+            assert 'line:' in message and 'col:' in message
+
     def test_self_ref_substitution_array_to_dict(self):
         config = ConfigFactory.parse_string(
             """


### PR DESCRIPTION
Fixes #103.

Parsing a `+=` self-append on a nested key whose self-reference stays unresolved crashes with a raw `AttributeError: 'bool' object has no attribute 'count'` instead of the intended error message. The `+=` desugaring builds the self-substitution and its `ConfigValues` with a boolean in the `instring` slot, where every other call site passes the source string; when the unresolved substitution is reported, `lineno(loc, instring)` calls `bool.count()` and raises.

Passing the real `instring` through both call sites makes it raise the intended `ConfigSubstitutionException` with a correct line and column. Working `+=` on an existing key is unaffected.

Repro:
```python
from pyhocon import ConfigFactory
ConfigFactory.parse_string('foo: {bar: []}\nfoo.bar += []')
```