### PR TITLE
Replace deprecated codecs.open for Python 3.14

### DIFF
--- a/pyhocon/config_parser.py
+++ b/pyhocon/config_parser.py
@@ -1,4 +1,3 @@
-import codecs
 import contextlib
 import copy
 import logging
@@ -100,7 +99,7 @@ class ConfigFactory(object):
         :type return: Config or list
         """
         try:
-            with codecs.open(filename, 'r', encoding=encoding) as fd:
+            with open(filename, 'r', encoding=encoding) as fd:
                 content = fd.read()
                 return cls.parse_string(content, os.path.dirname(filename), resolve, unresolved_value)
         except IOError as e:


### PR DESCRIPTION
## Summary

- Replace deprecated `codecs.open()` with the built-in `open()`.

## Why

Python 3.14 deprecates `codecs.open()` and recommends `open()` instead. This removes the deprecation warning from `ConfigFactory.parse_file()` and keeps the code compatible with future Python releases.