### PR TITLE
Raise ConfigException on an out-of-range period value

### DIFF
--- a/pyhocon/period_parser.py
+++ b/pyhocon/period_parser.py
@@ -3,6 +3,8 @@ from datetime import timedelta
 
 from pyparsing import (Word, ZeroOrMore, alphanums, Or, nums, WordEnd, Combine, Literal)
 
+from pyhocon.exceptions import ConfigException
+
 period_type_map = {
     'nanoseconds': ['ns', 'nano', 'nanos', 'nanosecond', 'nanoseconds'],
     'microseconds': ['us', 'micro', 'micros', 'microsecond', 'microseconds'],
@@ -36,7 +38,15 @@ def convert_period(tokens):
                         in period_type_map.items()
                         if period_identifier in values))
 
-    return period(period_value, period_unit)
+    try:
+        return period(period_value, period_unit)
+    except OverflowError as e:
+        # A millisecond period is built with timedelta, whose C-level day count
+        # overflows for a huge value like "99999999999999999999999 ms". Report
+        # it as a config error instead of leaking OverflowError out of parsing.
+        raise ConfigException(
+            "Period '{} {}' is out of range".format(period_value, period_identifier)
+        ) from e
 
 
 def period(period_value, period_unit):

--- a/tests/test_periods.py
+++ b/tests/test_periods.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 import pytest
 
+from pyhocon.exceptions import ConfigException
 from pyhocon.period_parser import parse_period
 from pyhocon.period_serializer import timedelta_to_hocon
 
@@ -100,3 +101,15 @@ def test_format_time_delta():
                                         (timedelta(seconds=51), '51 seconds'),
                                         (timedelta(microseconds=786), '786 microseconds')):
         assert expected_result == timedelta_to_hocon(time_delta)
+
+
+@pytest.mark.parametrize('representation', [
+    '99999999999999999999999 ms',
+    '999999999999999999999999999 milliseconds',
+])
+def test_out_of_range_millisecond_period_raises(representation):
+    # A millisecond period is built with timedelta, which overflows for an
+    # absurdly large value. That must surface as a ConfigException, not a raw
+    # OverflowError leaking out of parsing.
+    with pytest.raises(ConfigException):
+        parse_period(representation)


### PR DESCRIPTION
Parsing a config whose value is an absurdly large millisecond period crashes with a raw `OverflowError`:

```python
>>> from pyhocon import ConfigFactory
>>> ConfigFactory.parse_string('a = 99999999999999999999999 ms')
OverflowError: Python int too large to convert to C int
```

`convert_period` does `int(tokens.value)` on an unbounded digit run, and a millisecond period is built with `datetime.timedelta`, whose C-level day count overflows. Since `get_period_expr()` is part of `value_expr` in the parser, this fires at parse time, so any HOCON string containing such a value takes the whole parse down instead of reporting a config error.

The fix catches the overflow in `convert_period` and raises `ConfigException`. Normal periods are unaffected. Added a test in `tests/test_periods.py`.