### PR TITLE
Stop parse_key from splitting a compound key on an escaped quote

### DIFF
--- a/pyhocon/config_tree.py
+++ b/pyhocon/config_tree.py
@@ -202,12 +202,19 @@ class ConfigTree(OrderedDict):
         """
         special_characters = '$}[]:=+#`^?!@*&.'
         tokens = re.findall(
-            r'"[^"]+"|[^{special_characters}]+'.format(special_characters=re.escape(special_characters)), string)
+            r'"(?:[^"\\]|\\.)+"|[^{special_characters}]+'.format(special_characters=re.escape(special_characters)), string)
 
         def contains_special_character(token):
             return any((c in special_characters) for c in token)
 
-        return [token if contains_special_character(token) else token.strip('"') for token in tokens]
+        def unquote(token):
+            if token.startswith('"') and token.endswith('"'):
+                # local import to avoid a circular import with config_parser
+                from pyhocon.config_parser import ConfigParser
+                return re.sub(r'\\.', lambda m: ConfigParser.REPLACEMENTS.get(m.group(0), m.group(0)), token.strip('"'))
+            return token
+
+        return [token if contains_special_character(token) else unquote(token) for token in tokens]
 
     def put(self, key, value, append=False):
         """Put a value in the tree (dot separated)

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -221,6 +221,18 @@ class TestConfigParser(object):
         assert config['t.d.c'] == 5
         assert config['k."b.f.d"'] == 7
 
+    def test_quoted_key_with_escaped_quote(self):
+        # a key that starts with a backslash-escaped double quote used to get split on
+        # the raw, still-escaped `"` instead of being treated as one path element, which
+        # both corrupted the resulting key and could silently invent a bogus nested dict
+        # (see GH-325)
+        config = ConfigFactory.parse_string(
+            """
+            "\\"b" = 1
+            """
+        )
+        assert config['"b'] == 1
+
     def test_dotted_notation_merge(self):
         config = ConfigFactory.parse_string(
             """


### PR DESCRIPTION
While looking at #325 I found that ConfigTree.parse_key mis-splits a key whenever it contains an escaped quote followed by more content. The path-splitting regex's quoted alternative only matched non-quote characters between the delimiters, so something like `"\"b" = 1` gets read as a quote, a backslash, and another quote forming a complete (empty) token, with the rest of the string picked up separately afterward. In practice that turns into a two-level tree with a literal backslash as the top key, instead of one key holding the unescaped `"b`.

Made the quoted alternative escape-aware (same shape the tokenizer's own quoted-string regex already uses a few lines up in config_parser.py) and unescape whatever comes out of it using the same replacement table the value side already relies on. Kept it as "one or more" rather than "zero or more" so a run of bare adjacent quotes, which is how a triple-quoted key like `"""foo"""` shows up here, still falls through to the plain-run branch unchanged rather than getting eaten as a string of empty quoted tokens - that combination briefly broke `test_triple_quotes_keys` while I was working through this, which is what led me to that requirement in the first place.

I want to flag something honestly rather than oversell the scope: this doesn't fully close #325. The narrower case in that issue - a key that's nothing but a single escaped quote and no other characters - still fails, but earlier than parse_key: at the pyparsing grammar level, before parse_key ever gets called. I spent a while on it and couldn't pin down the mechanism with real confidence, so I'm not touching that part here. What's in this PR is a distinct, reproducible bug I could verify cleanly - the compound-key case - not a full fix for the issue's original repro.

Added a regression test (`test_quoted_key_with_escaped_quote`) confirming the fix; full suite passes (287 tests, one pre-existing xfail unrelated to this).